### PR TITLE
Update vec_env.py

### DIFF
--- a/mani_skill2/vector/vec_env.py
+++ b/mani_skill2/vector/vec_env.py
@@ -208,7 +208,7 @@ class VecEnv:
         self.waiting = False
         obs, rews, dones, infos = zip(*results)
         vec_obs = self.vectorize_obs(obs)
-        return vec_obs, rews, dones, infos
+        return vec_obs, np.array(rews), np.array(dones), infos
 
     def step(self, actions):
         self.step_async(actions)


### PR DESCRIPTION
Fix a minor bug, previously zip rewards and dones outputs a tuple. A lot of libraries expect an array so they can do something like

```
not_dones = 1.0 - dones
```

or
```
returns += rewards
```