### PR TITLE
Update requirements.txt to deal with AttributeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ numpy<1.24
 scipy
 gym>=0.18.3,<=0.21.0
 sapien==2.2.1
-# compatible with gym 0.21.0
-importlib-metadata==4.13.0
+importlib_metadata<5; python_version < '3.8'
 # basic
 h5py
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ numpy<1.24
 scipy
 gym>=0.18.3,<=0.21.0
 sapien==2.2.1
+# compatible with gym 0.21.0
+importlib-metadata==4.13.0
 # basic
 h5py
 pyyaml


### PR DESCRIPTION
When running the demo script, I was getting the error:

```
  File "/home/mittalma/.virtualenvs/maniskill2/lib/python3.7/site-packages/gym/__init__.py", line 13, in <module>
    from gym.envs import make, spec, register
  File "/home/mittalma/.virtualenvs/maniskill2/lib/python3.7/site-packages/gym/envs/__init__.py", line 10, in <module>
    _load_env_plugins()
  File "/home/mittalma/.virtualenvs/maniskill2/lib/python3.7/site-packages/gym/envs/registration.py", line 250, in load_env_plugins
    for plugin in metadata.entry_points().get(entry_point, []):
AttributeError: 'EntryPoints' object has no attribute 'get'
```

This is because gym 0.21.0 still uses EntryPoint that got deprecated from importlib 5.0 onwards.

Related stack overflow thread: https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean