### PR TITLE
trivial pr: `cameras` render mode

### DIFF
--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -1009,7 +1009,7 @@ class BaseEnv(gym.Env):
                     continue
                 camera.capture()
                 # TODO (stao): the output of this is not the same as gpu setting, its float here
-                rgb = (camera.get_picture("Color")[0, ..., :3] * 255).to(torch.uint8)
+                rgb = (camera.get_picture("Color")[..., :3] * 255).to(torch.uint8)
                 images.append(rgb)
         if len(images) == 0:
             return None
@@ -1030,6 +1030,20 @@ class BaseEnv(gym.Env):
         for sensor_images in sensor_images.values():
             images.extend(observations_to_images(sensor_images))
         return tile_images(images)
+    
+    def render_cameras(self):
+        """
+        Renders all cameras, including human render cameras and agent sensors.
+        """
+        images = []
+        for obj in self._hidden_objects:
+            obj.hide_visual()
+        self.update_render()
+        self.capture_sensor_data()
+        sensor_images = self.get_sensor_obs()
+        for sensor_images in sensor_images.values():
+            images.extend(observations_to_images(sensor_images))
+        return tile_images([self.render_rgb_array()] + images)
 
     def render(self):
         """
@@ -1047,6 +1061,8 @@ class BaseEnv(gym.Env):
             return self.render_rgb_array()
         elif self.render_mode == "sensors":
             return self.render_sensors()
+        elif self.render_mode == "cameras":
+            return self.render_cameras()
         else:
             raise NotImplementedError(f"Unsupported render mode {self.render_mode}.")
 

--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -1009,7 +1009,7 @@ class BaseEnv(gym.Env):
                     continue
                 camera.capture()
                 # TODO (stao): the output of this is not the same as gpu setting, its float here
-                rgb = (camera.get_picture("Color")[..., :3] * 255).to(torch.uint8)
+                rgb = (camera.get_picture("Color")[..., :3]).to(torch.uint8)
                 images.append(rgb)
         if len(images) == 0:
             return None

--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -1030,20 +1030,6 @@ class BaseEnv(gym.Env):
         for sensor_images in sensor_images.values():
             images.extend(observations_to_images(sensor_images))
         return tile_images(images)
-    
-    def render_cameras(self):
-        """
-        Renders all cameras, including human render cameras and agent sensors.
-        """
-        images = []
-        for obj in self._hidden_objects:
-            obj.hide_visual()
-        self.update_render()
-        self.capture_sensor_data()
-        sensor_images = self.get_sensor_obs()
-        for sensor_images in sensor_images.values():
-            images.extend(observations_to_images(sensor_images))
-        return tile_images([self.render_rgb_array()] + images)
 
     def render(self):
         """
@@ -1061,8 +1047,6 @@ class BaseEnv(gym.Env):
             return self.render_rgb_array()
         elif self.render_mode == "sensors":
             return self.render_sensors()
-        elif self.render_mode == "cameras":
-            return self.render_cameras()
         else:
             raise NotImplementedError(f"Unsupported render mode {self.render_mode}.")
 

--- a/mani_skill2/utils/visualization/misc.py
+++ b/mani_skill2/utils/visualization/misc.py
@@ -7,9 +7,10 @@ import numpy as np
 import torch
 import tqdm
 
+from mani_skill2.utils.structs.types import Array
 
 def images_to_video(
-    images: List[np.ndarray],
+    images: List[Array],
     output_dir: str,
     video_name: str,
     fps: int = 10,
@@ -59,7 +60,7 @@ def normalize_depth(depth, min_depth=0, max_depth=None):
     return depth
 
 
-def observations_to_images(observations, max_depth=None) -> List[np.ndarray]:
+def observations_to_images(observations, max_depth=None) -> List[Array]:
     """Parse images from camera observations."""
     images = []
     # is_torch = False
@@ -88,13 +89,13 @@ def observations_to_images(observations, max_depth=None) -> List[np.ndarray]:
                 depth = torch.repeat_interleave(depth, 3, dim=-1)
             images.append(depth)
         elif "seg" in key:
-            seg: np.ndarray = observations[key]  # [H, W, 1]
+            seg: Array = observations[key]  # [H, W, 1]
             assert seg.ndim == 3 and seg.shape[-1] == 1, seg.shape
             # A heuristic way to colorize labels
             seg = np.uint8(seg * [11, 61, 127])  # [H, W, 3]
             images.append(seg)
         elif "Segmentation" in key:
-            seg: np.ndarray = observations[key]  # [H, W, 4]
+            seg: Array = observations[key]  # [H, W, 4]
             assert seg.ndim == 3 and seg.shape[-1] == 4, seg.shape
             # A heuristic way to colorize labels
             visual_seg = np.uint8(seg[..., 0:1] * [11, 61, 127])  # [H, W, 3]
@@ -104,7 +105,7 @@ def observations_to_images(observations, max_depth=None) -> List[np.ndarray]:
     return images
 
 
-def tile_images(images: List[np.ndarray], nrows=1) -> np.ndarray:
+def tile_images(images: List[Array], nrows=1) -> Array:
     """
     Tile multiple images to a single image comprised of nrows and an appropriate number of columns to fit all the images.
     The images can also be batched (e.g. of shape (B, H, W, C)), but give images must all have the same batch size.
@@ -168,7 +169,7 @@ def tile_images(images: List[np.ndarray], nrows=1) -> np.ndarray:
     return output_image
 
 
-def put_text_on_image(image: np.ndarray, lines: List[str]):
+def put_text_on_image(image: Array, lines: List[str]):
     assert image.dtype == np.uint8, image.dtype
     image = image.copy()
 
@@ -194,7 +195,7 @@ def put_text_on_image(image: np.ndarray, lines: List[str]):
     return image
 
 
-def append_text_to_image(image: np.ndarray, lines: List[str]):
+def append_text_to_image(image: Array, lines: List[str]):
     r"""Appends text left to an image of size (height, width, channels).
     The returned image has white text on a black background.
     Args:


### PR DESCRIPTION
ik we changed cameras to sensors for a reason, but is it ok to add this back since it's useful:

changes
- added camera render which combines human cameras and agent sensors
- fix inverted color bug for human cameras on cpu
- small typing stuff

justification
- it's useful to see both in my log videos
- render_sensors is too small to fit all info_on_video content (since human render is 512x512, while fetch's sensors are 128x128)

testing
- my fetch rl code

https://github.com/haosulab/ManiSkill2/assets/44527268/9ae4a84b-bdc3-4d2c-8738-e9a2b4b7b3ba


not addressed here
- currently vis utils not written in `physx.is_gpu_enabled` format; did not change since iirc we might be moving away from this. if we don't then will need to change later
