### PR TITLE
Fix actor show/hide visual gpu sim

### DIFF
--- a/examples/benchmarking/benchmark_maniskill.py
+++ b/examples/benchmarking/benchmark_maniskill.py
@@ -12,8 +12,6 @@ import torch
 import tqdm
 
 import mani_skill2.envs
-from mani_skill2.envs.scenes.tasks.planner.planner import PickSubtask
-from mani_skill2.envs.scenes.tasks.sequential_task import SequentialTaskEnv
 from mani_skill2.utils.scene_builder.ai2thor.variants import ArchitecTHORSceneBuilder
 from mani_skill2.utils.scene_builder.replicacad.scene_builder import ReplicaCADSceneBuilder
 from mani_skill2.vector.wrappers.gymnasium import ManiSkillVectorEnv

--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -446,15 +446,12 @@ class BaseEnv(gym.Env):
             obj.hide_visual()
         self._scene.update_render()
         self.capture_sensor_data()
-        obs = OrderedDict(
+        return OrderedDict(
             agent=self._get_obs_agent(),
             extra=self._get_obs_extra(info),
             sensor_param=self.get_sensor_params(),
             sensor_data=self.get_sensor_obs(),
         )
-        for obj in self._hidden_objects:
-            obj.show_visual()
-        return obs
 
     @property
     def robot_link_ids(self):
@@ -965,6 +962,8 @@ class BaseEnv(gym.Env):
             )
 
     def render_human(self):
+        for obj in self._hidden_objects:
+            obj.show_visual()
         if self._viewer is None:
             self._viewer = Viewer()
             self._setup_viewer()
@@ -981,6 +980,8 @@ class BaseEnv(gym.Env):
         """Returns an RGB array / image of size (num_envs, H, W, 3) of the current state of the environment.
         This is captured by any of the registered human render cameras. If a camera_name is given, only data from that camera is returned.
         Otherwise all camera data is captured and returned as a single batched image"""
+        for obj in self._hidden_objects:
+            obj.show_visual()
         self._scene.update_render()
         images = []
         # TODO (stao): refactor this code either into ManiSkillScene class and/or merge the code, it's pretty similar?
@@ -1007,6 +1008,8 @@ class BaseEnv(gym.Env):
             return None
         if len(images) == 1:
             return images[0]
+        for obj in self._hidden_objects:
+            obj.hide_visual()
         return tile_images(images)
 
     def render_sensors(self):
@@ -1021,8 +1024,6 @@ class BaseEnv(gym.Env):
         sensor_images = self.get_sensor_obs()
         for sensor_images in sensor_images.values():
             images.extend(observations_to_images(sensor_images))
-        for obj in self._hidden_objects:
-            obj.show_visual()
         return tile_images(images)
 
     def render(self):

--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -978,6 +978,8 @@ class BaseEnv(gym.Env):
         if physx.is_gpu_enabled() and self._scene._gpu_sim_initialized:
             self.physx_system.sync_poses_gpu_to_cpu()
         self._viewer.render()
+        for obj in self._hidden_objects:
+            obj.hide_visual()
         return self._viewer
 
     def render_rgb_array(self, camera_name: str = None):

--- a/mani_skill2/envs/sapien_env.py
+++ b/mani_skill2/envs/sapien_env.py
@@ -644,6 +644,10 @@ class BaseEnv(gym.Env):
         self._set_episode_rng(self._episode_seed)
         self.agent.reset()
         self.initialize_episode(env_idx)
+        # reset the reset mask back to all ones so any internal code in maniskill can continue to manipulate all scenes at once as usual
+        self._scene._reset_mask = torch.ones(
+            self.num_envs, dtype=bool, device=self.device
+        )
         obs = self.get_obs()
         if physx.is_gpu_enabled():
             # ensure all updates to object poses and configurations are applied on GPU after task initialization

--- a/mani_skill2/utils/structs/actor.py
+++ b/mani_skill2/utils/structs/actor.py
@@ -174,12 +174,15 @@ class Actor(PhysxRigidDynamicComponentStruct, BaseStruct[sapien.Entity]):
             self._objs[0].find_component_by_type(
                 sapien.render.RenderBodyComponent
             ).visibility = 0
+        # set hidden *after* setting/getting so not applied to self.before_hide_pose erroenously
         self.hidden = True
 
     def show_visual(self):
         assert not self.has_collision_shapes()
         if not self.hidden:
             return
+        # set hidden *before* setting/getting so not applied to self.before_hide_pose erroenously
+        self.hidden = False
         if physx.is_gpu_enabled():
             if hasattr(self, "before_hide_pose"):
                 self.pose = self.before_hide_pose
@@ -189,7 +192,6 @@ class Actor(PhysxRigidDynamicComponentStruct, BaseStruct[sapien.Entity]):
             self._objs[0].find_component_by_type(
                 sapien.render.RenderBodyComponent
             ).visibility = 1
-        self.hidden = False
 
     def is_static(self, lin_thresh=1e-2, ang_thresh=1e-1):
         """

--- a/mani_skill2/utils/structs/actor.py
+++ b/mani_skill2/utils/structs/actor.py
@@ -150,9 +150,6 @@ class Actor(PhysxRigidDynamicComponentStruct, BaseStruct[sapien.Entity]):
             > 0
         )
 
-    # NOTE (arth): when using hide/show_visual on gpu sim, should call
-    #       hide_visual, then soon after show_visual, such that
-    #       poses are not incorrectly updated in between
     def hide_visual(self):
         """
         Hides this actor from view. In CPU simulation the visual body is simply set to visibility 0
@@ -246,4 +243,7 @@ class Actor(PhysxRigidDynamicComponentStruct, BaseStruct[sapien.Entity]):
             self._objs[0].pose = to_sapien_pose(arg1)
 
     def set_pose(self, arg1: Union[Pose, sapien.Pose]) -> None:
-        self.pose = arg1
+        if physx.is_gpu_enabled() and self.hidden:
+            self.before_hide_pose = vectorize_pose(arg1)
+        else:
+            self.pose = arg1

--- a/tests/test_gpu_envs.py
+++ b/tests/test_gpu_envs.py
@@ -249,4 +249,101 @@ def test_timelimits(env_id):
     del env
 
 
+@pytest.mark.gpu_sim
+@pytest.mark.parametrize("env_id", ["PickCube-v1"])
+def test_hidden_objs(env_id):
+    env: ManiSkillVectorEnv = gym.make_vec(env_id, num_envs=16, vectorization_mode="custom")
+    obs, _ = env.reset()
+    
+    # for PickCube, this is env.goal_site
+    hide_obj = env.unwrapped._hidden_objects[0]
+
+    raw_pose = hide_obj.pose.raw_pose.clone()
+    p = hide_obj.pose.p.clone()
+    q = hide_obj.pose.q.clone()
+    linvel = hide_obj.linear_velocity.clone()
+    angvel = hide_obj.angular_velocity.clone()
+
+    # hide_visual tests
+    hide_obj.hide_visual()
+
+    # 1. check relevant hidden properties are active
+    assert hide_obj.hidden
+    assert hasattr(hide_obj, "before_hide_pose")
+
+    # 2. check state data for new pos is not too low or high
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., :3] > 1e3
+    ).all()
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., :3] < 1e6
+    ).all()
+
+    # 3. check that linvel and angvel same as before
+    assert (hide_obj.linear_velocity == linvel).all()
+    assert (hide_obj.angular_velocity == angvel).all()
+
+    # 4. Check data stored in buffer has same q but different p
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., :3] != p
+    ).all()
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., 3:] == q
+    ).all()
+
+    # 5. Check data stored in before_hide_pose has same q and p
+    assert (hide_obj.before_hide_pose[..., :3] == p).all()
+    assert (hide_obj.before_hide_pose[..., 3:] == q).all()
+
+    # 6. check that direct calls to raw_pose, pos, and rot same as before
+    #       (should return `before_hide_pose`)
+    assert (hide_obj.pose.raw_pose == raw_pose).all()
+    assert (hide_obj.pose.p == p).all()
+    assert (hide_obj.pose.q == q).all()
+    assert (hide_obj.pose.raw_pose == hide_obj.before_hide_pose).all()
+
+    # show_visual tests
+    hide_obj.show_visual()
+
+    # 1. check relevant hidden properties are active
+    assert not hide_obj.hidden
+    
+    # 2. check that qvel, linvel, angvel same as before
+    assert (hide_obj.linear_velocity == linvel).all()
+    assert (hide_obj.angular_velocity == angvel).all()
+
+    # 3. check gpu buffer goes back to normal
+    print(
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., :3]
+    )
+    print(p)
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., :3] == p
+    ).all()
+    assert (
+        hide_obj.px.cuda_rigid_body_data.torch()[
+            hide_obj._body_data_index, :7
+        ].clone()[..., 3:] == q
+    ).all()
+
+    # 4. check that direct calls to raw_pose, pos, and rot same as before
+    assert (hide_obj.pose.raw_pose == raw_pose).all()
+    assert (hide_obj.pose.p == p).all()
+    assert (hide_obj.pose.q == q).all()
+
+    env.close()
+    del env
+
 # TODO (stao): Add test for tasks where there is no success/success and failure/no success or failure


### PR DESCRIPTION
tested on gpu and cpu sim, checked depth camera obs as well

## **REIMPLEMENTED**
- by default hidden objs are hidden
- if hidden actor pose is changed, save to `self.before_hide_pose` so it can be applied once actor is un-hidden