### PR TITLE
Pick clutter task (GPU)

### DIFF
--- a/docs/source/user_guide/tutorials/custom_tasks_advanced.md
+++ b/docs/source/user_guide/tutorials/custom_tasks_advanced.md
@@ -131,9 +131,11 @@ class GPUMemoryConfig:
     temp_buffer_capacity: int = 2**24
     """Increase this if you get 'PxgPinnedHostLinearMemoryAllocator: overflowing initial allocation size, increase capacity to at least %.' """
     max_rigid_contact_count: int = 2**19
+    """Increase this if you get 'Contact buffer overflow detected'"""
     max_rigid_patch_count: int = (
         2**18
     )  # 81920 is SAPIEN default but most tasks work with 2**18
+    """Increase this if you get 'Patch buffer overflow detected'"""
     heap_capacity: int = 2**26
     found_lost_pairs_capacity: int = (
         2**25
@@ -143,7 +145,6 @@ class GPUMemoryConfig:
 
     def dict(self):
         return {k: v for k, v in asdict(self).items()}
-
 
 @dataclass
 class SceneConfig:

--- a/mani_skill/agents/controllers/pd_ee_pose.py
+++ b/mani_skill/agents/controllers/pd_ee_pose.py
@@ -104,7 +104,7 @@ class PDEEPosController(PDJointPosController):
             ] = self.ee_pose_at_base.raw_pose[self.scene._reset_mask]
 
     def compute_ik(
-        self, target_pose: Pose, action: Array, pos_only=False, max_iterations=100
+        self, target_pose: Pose, action: Array, pos_only=True, max_iterations=100
     ):
         # Assume the target pose is defined in the base frame
         if physx.is_gpu_enabled():
@@ -241,6 +241,11 @@ class PDEEPoseController(PDEEPosController):
         ]
         rot_action = rot_action * self.config.rot_bound
         return torch.hstack([pos_action, rot_action])
+
+    def compute_ik(self, target_pose: Pose, action: Array, max_iterations=100):
+        return super().compute_ik(
+            target_pose, action, pos_only=False, max_iterations=max_iterations
+        )
 
     def compute_target_pose(self, prev_ee_pose_at_base: Pose, action):
         if self.config.use_delta:

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -664,6 +664,9 @@ class BaseEnv(gym.Env):
                 self._reconfigure(options)
                 self._after_reconfigure(options)
 
+        # TODO (stao): Reconfiguration when there is partial reset might not make sense and certainly broken here now.
+        # Solution to resolve that would be to ensure tasks that do reconfigure more than once are single-env only / cpu sim only
+        # or disable partial reset features explicitly for tasks that have a reconfiguration frequency
         if "env_idx" in options:
             env_idx = options["env_idx"]
             self._scene._reset_mask = torch.zeros(

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -655,6 +655,7 @@ class BaseEnv(gym.Env):
                 torch.manual_seed(seed=self._episode_seed)
                 self._reconfigure(options)
                 self._after_reconfigure(options)
+
         if "env_idx" in options:
             env_idx = options["env_idx"]
             self._scene._reset_mask = torch.zeros(

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -628,6 +628,14 @@ class BaseEnv(gym.Env):
         options["reconfigure"] is True, will call self._reconfigure() which deletes the entire physx scene and reconstructs everything.
         Users building custom tasks generally do not need to override this function.
 
+        Returns the first observation and a info dictionary. The info dictionary is of type
+        ```
+        {
+            "reconfigure": bool (True if the environment reconfigured. False otherwise)
+        }
+
+
+
         Note that ManiSkill always holds two RNG states, a main RNG, and an episode RNG. The main RNG is used purely to sample an episode seed which
         helps with reproducibility of episodes and is for internal use only. The episode RNG is used by the environment/task itself to
         e.g. randomize object positions, randomize assets etc. Episode RNG is accessible by using torch.rand (recommended) which is seeded with a
@@ -695,7 +703,7 @@ class BaseEnv(gym.Env):
         if not physx.is_gpu_enabled():
             obs = sapien_utils.to_numpy(sapien_utils.unbatch(obs))
             self._elapsed_steps = 0
-        return obs, {}
+        return obs, dict(reconfigure=reconfigure)
 
     def _set_main_rng(self, seed):
         """Set the main random generator which is only used to set the seed of the episode RNG to improve reproducibility.

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -49,6 +49,11 @@ class ManiSkillScene:
         self.actors: Dict[str, Actor] = OrderedDict()
         self.articulations: Dict[str, Articulation] = OrderedDict()
 
+        self.actor_views: Dict[str, Actor] = OrderedDict()
+        """views of actors in any sub-scenes created by using Actor.merge and queryable as if it were a single Actor"""
+        self.articulation_views: Dict[str, Articulation] = OrderedDict()
+        """views of articulations in any sub-scenes created by using Articulation.merge and queryable as if it were a single Articulation"""
+
         self.sensors: Dict[str, BaseSensor] = OrderedDict()
         self.human_render_cameras: Dict[str, Camera] = OrderedDict()
 
@@ -527,7 +532,7 @@ class ManiSkillScene:
         # As physx_system.gpu_init() was called a single physx step was also taken. So we need to reset
         # all the actors and articulations to their original poses as they likely have collided
         for actor in self.non_static_actors:
-            actor.set_pose(actor._builder_initial_pose)
+            actor.set_pose(actor.inital_pose)
         self.px.cuda_rigid_body_data.torch()[:, 7:] = (
             self.px.cuda_rigid_body_data.torch()[:, 7:] * 0
         )  # zero out all velocities

--- a/mani_skill/envs/tasks/__init__.py
+++ b/mani_skill/envs/tasks/__init__.py
@@ -5,13 +5,14 @@ from .fmb import FMBAssembly1Env
 from .lift_peg_upright import LiftPegUprightEnv
 from .open_cabinet_drawer import OpenCabinetDoorEnv, OpenCabinetDrawerEnv
 from .peg_insertion_side import PegInsertionSideEnv
+from .pick_clutter_ycb import PickClutterYCBEnv
 from .pick_cube import PickCubeEnv
 from .pick_single_ycb import PickSingleYCBEnv
 from .pull_cube import PullCubeEnv
 from .push_cube import PushCubeEnv
 from .quadruped_run import QuadrupedRunEnv
 from .quadruped_stand import QuadrupedStandEnv
+from .rotate_cube import RotateCubeEnv
 from .stack_cube import StackCubeEnv
 from .two_robot_pick_cube import TwoRobotPickCube
 from .two_robot_stack_cube import TwoRobotStackCube
-from .rotate_cube import RotateCubeEnv

--- a/mani_skill/envs/tasks/pick_clutter_ycb.py
+++ b/mani_skill/envs/tasks/pick_clutter_ycb.py
@@ -24,6 +24,7 @@ from mani_skill.utils.structs.types import SimConfig
 class PickClutterEnv(BaseEnv):
     """Base environment picking items out of clutter type of tasks. Flexibly supports using different configurations and object datasets"""
 
+    SUPPORTED_REWARD_MODES = ["sparse", "none"]
     SUPPORTED_ROBOTS = ["panda", "fetch"]
     agent: Union[Panda, Fetch]
 

--- a/mani_skill/envs/tasks/pick_clutter_ycb.py
+++ b/mani_skill/envs/tasks/pick_clutter_ycb.py
@@ -17,7 +17,7 @@ from mani_skill.utils.io_utils import load_json
 from mani_skill.utils.registration import register_env
 from mani_skill.utils.scene_builder.table.table_scene_builder import TableSceneBuilder
 from mani_skill.utils.structs import Actor, Pose
-from mani_skill.utils.structs.types import SimConfig
+from mani_skill.utils.structs.types import GPUMemoryConfig, SimConfig
 
 
 #
@@ -38,8 +38,6 @@ class PickClutterEnv(BaseEnv):
         robot_uids="panda",
         robot_init_qpos_noise=0.02,
         episode_json: str = None,
-        asset_root: str = None,
-        model_json: str = None,
         **kwargs,
     ):
         self.robot_init_qpos_noise = robot_init_qpos_noise
@@ -63,7 +61,11 @@ class PickClutterEnv(BaseEnv):
 
     @property
     def _default_sim_cfg(self):
-        return SimConfig()
+        return SimConfig(
+            gpu_memory_cfg=GPUMemoryConfig(
+                max_rigid_contact_count=2**21, max_rigid_patch_count=2**19
+            )
+        )
 
     @property
     def _sensor_configs(self):

--- a/mani_skill/envs/tasks/pick_clutter_ycb.py
+++ b/mani_skill/envs/tasks/pick_clutter_ycb.py
@@ -116,7 +116,7 @@ class PickClutterEnv(BaseEnv):
                     # TODO (stao): what is rep_pts?, this is taken from ms2 code
                     self.selectable_target_objects[-1].append(obj)
             selected_obj_idxs[i] = selected_obj_idxs[i] % len(
-                self.selectable_target_objects
+                self.selectable_target_objects[-1]
             )
             target_objects.append(
                 self.selectable_target_objects[-1][selected_obj_idxs[i]]

--- a/mani_skill/envs/tasks/pick_clutter_ycb.py
+++ b/mani_skill/envs/tasks/pick_clutter_ycb.py
@@ -1,0 +1,141 @@
+import os
+from collections import OrderedDict
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import sapien
+import torch
+
+from mani_skill import ASSET_DIR
+from mani_skill.agents.robots import Fetch, Panda
+from mani_skill.envs.sapien_env import BaseEnv
+from mani_skill.sensors.camera import CameraConfig
+from mani_skill.utils import sapien_utils
+from mani_skill.utils.building import actors
+from mani_skill.utils.building.actor_builder import ActorBuilder
+from mani_skill.utils.io_utils import load_json
+from mani_skill.utils.registration import register_env
+from mani_skill.utils.scene_builder.table.table_scene_builder import TableSceneBuilder
+from mani_skill.utils.structs.types import SimConfig
+
+
+#
+class PickClutterEnv(BaseEnv):
+    """Base environment picking items out of clutter type of tasks. Flexibly supports using different configurations and object datasets"""
+
+    SUPPORTED_ROBOTS = ["panda", "fetch"]
+    agent: Union[Panda, Fetch]
+
+    DEFAULT_EPISODE_JSON: str
+    DEFAULT_ASSET_ROOT: str
+    DEFAULT_MODEL_JSON: str
+
+    def __init__(
+        self,
+        *args,
+        robot_uids="panda",
+        robot_init_qpos_noise=0.02,
+        episode_json: str = None,
+        asset_root: str = None,
+        model_json: str = None,
+        **kwargs,
+    ):
+        self.robot_init_qpos_noise = robot_init_qpos_noise
+
+        if episode_json is None:
+            episode_json = self.DEFAULT_EPISODE_JSON
+        if not os.path.exists(episode_json):
+            raise FileNotFoundError(
+                f"Episode json ({episode_json}) is not found."
+                "To download default json:"
+                "`python -m mani_skill2.utils.download_asset pick_clutter_ycb`."
+            )
+        self._episodes: List[Dict] = load_json(episode_json)
+
+        super().__init__(*args, robot_uids=robot_uids, **kwargs)
+
+    @property
+    def _default_sim_cfg(self):
+        return SimConfig()
+
+    @property
+    def _sensor_configs(self):
+        pose = sapien_utils.look_at(eye=[0.3, 0, 0.6], target=[-0.1, 0, 0.1])
+        return [
+            CameraConfig(
+                "base_camera",
+                pose=pose,
+                width=128,
+                height=128,
+                fov=np.pi / 2,
+                near=0.01,
+                far=100,
+            )
+        ]
+
+    @property
+    def _human_render_camera_configs(self):
+        pose = sapien_utils.look_at([0.6, 0.7, 0.6], [0.0, 0.0, 0.35])
+        return CameraConfig(
+            "render_camera", pose=pose, width=512, height=512, fov=1, near=0.01, far=100
+        )
+
+    def _load_model(self, model_id: str) -> ActorBuilder:
+        raise NotImplementedError()
+
+    def _load_scene(self, options: dict):
+        self.scene_builder = TableSceneBuilder(
+            self, robot_init_qpos_noise=self.robot_init_qpos_noise
+        )
+        self.scene_builder.build()
+
+        # sample some clutter configurations
+        eps_idxs = np.arange(0, len(self._episodes))
+        rand_idx = torch.randperm(len(eps_idxs), device=torch.device("cpu"))
+        eps_idxs = eps_idxs[rand_idx]
+        eps_idxs = np.concatenate(
+            [eps_idxs] * np.ceil(self.num_envs / len(eps_idxs)).astype(int)
+        )[: self.num_envs]
+        # import ipdb;ipdb.set_trace()
+        for i, eps_idx in enumerate(eps_idxs):
+            [i]
+            episode = self._episodes[eps_idx]
+            for actor_cfg in episode["actors"]:
+                builder = self._load_model(actor_cfg["model_id"])
+                init_pose = actor_cfg["pose"]
+                builder.initial_pose = sapien.Pose(p=init_pose[:3], q=init_pose[3:])
+                obj = builder.build(name=actor_cfg["model_id"])
+
+    def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
+        self.scene_builder.initialize(env_idx)
+
+    def evaluate(self):
+        return {
+            "success": torch.zeros(self.num_envs, device=self.device, dtype=bool),
+            "fail": torch.zeros(self.num_envs, device=self.device, dtype=bool),
+        }
+
+    def _get_obs_extra(self, info: Dict):
+        return OrderedDict()
+
+    def compute_dense_reward(self, obs: Any, action: torch.Tensor, info: Dict):
+        return torch.zeros(self.num_envs, device=self.device)
+
+    def compute_normalized_dense_reward(
+        self, obs: Any, action: torch.Tensor, info: Dict
+    ):
+        max_reward = 1.0
+        return self.compute_dense_reward(obs=obs, action=action, info=info) / max_reward
+
+
+@register_env("PickClutterYCB-v1", max_episode_steps=100)
+class PickClutterYCBEnv(PickClutterEnv):
+    DEFAULT_EPISODE_JSON = f"{ASSET_DIR}/tasks/pick_clutter/ycb_train_5k.json.gz"
+    # DEFAULT_ASSET_ROOT = f""
+    # DEFAULT_MODEL_JSON = PickSingleYCBEnv.DEFAULT_MODEL_JSON
+
+    def _load_model(self, model_id):
+        builder, _ = actors.build_actor_ycb(
+            model_id, self._scene, name=model_id, return_builder=True
+        )
+        return builder

--- a/mani_skill/envs/tasks/pick_clutter_ycb.py
+++ b/mani_skill/envs/tasks/pick_clutter_ycb.py
@@ -192,8 +192,6 @@ class PickClutterEnv(BaseEnv):
 @register_env("PickClutterYCB-v1", max_episode_steps=100)
 class PickClutterYCBEnv(PickClutterEnv):
     DEFAULT_EPISODE_JSON = f"{ASSET_DIR}/tasks/pick_clutter/ycb_train_5k.json.gz"
-    # DEFAULT_ASSET_ROOT = f""
-    # DEFAULT_MODEL_JSON = PickSingleYCBEnv.DEFAULT_MODEL_JSON
 
     def _load_model(self, model_id):
         builder, _ = actors.build_actor_ycb(

--- a/mani_skill/envs/tasks/pick_single_ycb.py
+++ b/mani_skill/envs/tasks/pick_single_ycb.py
@@ -97,6 +97,7 @@ class PickSingleYCBEnv(BaseEnv):
         actors: List[Actor] = []
         self.obj_heights = []
         for i, model_id in enumerate(model_ids):
+            # TODO: before official release we will finalize a metadata dataclass that these build functions should return.
             builder, obj_height = build_actor_ycb(
                 model_id, self._scene, name=model_id, return_builder=True
             )

--- a/mani_skill/utils/building/actor_builder.py
+++ b/mani_skill/utils/building/actor_builder.py
@@ -213,10 +213,8 @@ class ActorBuilder(SAPIENActorBuilder):
             and initial_pose_b == 1
             and physx.is_gpu_enabled()
         ):
-            actor._builder_initial_pose = Pose.create(
-                initial_pose.raw_pose.repeat(num_actors, 1)
-            )
+            actor.inital_pose = Pose.create(initial_pose.raw_pose.repeat(num_actors, 1))
         else:
-            actor._builder_initial_pose = initial_pose
+            actor.inital_pose = initial_pose
         self.scene.actors[self.name] = actor
         return actor

--- a/mani_skill/utils/download_asset.py
+++ b/mani_skill/utils/download_asset.py
@@ -28,7 +28,10 @@ class DataSource:
     url: str = None
     hf_repo_id: str = None
     target_path: str = None
+    """the folder where the file will be downloaded to"""
     checksum: str = None
+    filename: str = None
+    """name to change the downloaded file to. If None, will not change the name"""
     output_dir: str = ASSET_DIR
 
 
@@ -200,7 +203,9 @@ def download(
     non_interactive=True,
 ):
     output_dir = Path(data_source.output_dir)
-
+    base_filename = data_source.filename
+    if base_filename is None:
+        base_filename = data_source.url.split("/")[-1]
     # Create output directory
     if not output_dir.exists():
         if non_interactive or prompt_yes_no(f"{output_dir} does not exist. Create?"):
@@ -226,7 +231,7 @@ def download(
             else:
                 print(f"Skip existing: {output_path}")
                 return output_path
-
+    output_path.mkdir(parents=True, exist_ok=True)
     if data_source.hf_repo_id is not None:
         download_from_hf_datasets(data_source)
         return
@@ -243,7 +248,7 @@ def download(
                     pbar.total = size
                 pbar.update(bs)
 
-        filename, _ = urllib.request.urlretrieve(
+        tmp_filename, _ = urllib.request.urlretrieve(
             data_source.url, reporthook=show_progress
         )
         if verbose:
@@ -253,24 +258,27 @@ def download(
         raise err
 
     # Verify checksum
-    if data_source.checksum is not None and data_source.checksum != sha256sum(filename):
+    if data_source.checksum is not None and data_source.checksum != sha256sum(
+        tmp_filename
+    ):
         raise IOError(
             f"Downloaded file's SHA-256 hash does not match record: {data_source.url}"
         )
+    # import ipdb;ipdb.set_trace()
     # Extract or move to output path
     if data_source.url.endswith(".zip"):
-        with zipfile.ZipFile(filename, "r") as zip_ref:
+        with zipfile.ZipFile(tmp_filename, "r") as zip_ref:
             if verbose:
                 for file in tqdm(zip_ref.infolist()):
                     zip_ref.extract(file, output_dir)
             else:
                 zip_ref.extractall(output_dir)
     else:
-        shutil.move(filename, output_path)
+        shutil.move(tmp_filename, output_path / base_filename)
 
     # Explicitly delete the temporary file
-    if Path(filename).exists():
-        Path(filename).unlink()
+    if Path(tmp_filename).exists():
+        Path(tmp_filename).unlink()
 
     return output_path
 

--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -32,13 +32,19 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
     px_body_type: Literal["kinematic", "static", "dynamic"] = None
     hidden: bool = False
 
-    # track the initial pose of the actor builder for this actor. Necessary to ensure the actor is reset correctly once
-    # gpu system is initialized
-    _builder_initial_pose: Pose = None
+    inital_pose: Pose = None
+    """
+    The initial pose of this Actor, as defined when creating the actor via the ActorBuilder. It is necessary to track
+    this pose to ensure the actor is still at the correct pose once gpu system is initialized. It may also be useful
+    to help reset a environment to an initial state without having to manage initial poses yourself
+    """
     name: str = None
 
     def __hash__(self):
         return self._objs[0].__hash__()
+
+    def __str__(self):
+        return f"<{self.name}: struct of type {self.__class__}; managing {self._num_objs} {self._objs[0].__class__} objects>"
 
     @classmethod
     def create_from_entities(
@@ -81,7 +87,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
     @classmethod
     def merge(cls, actors: List["Actor"], name: str = None):
         """
-        Merge actors together so that they can all be managed by one python dataclass object.
+        Merge actors together under one view so that they can all be managed by one python dataclass object.
         This can be useful for e.g. randomizing the asset loaded into a task and being able to do object.pose to fetch the pose of all randomized assets
         or object.set_pose to change the pose of each of the different assets, despite the assets not being uniform across all sub-scenes.
 
@@ -99,8 +105,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
         for actor in actors:
             objs += actor._objs
             merged_scene_idxs.append(actor._scene_idxs)
-            _builder_initial_poses.append(actor._builder_initial_pose.raw_pose)
-            del scene.actors[actor.name]
+            _builder_initial_poses.append(actor.inital_pose.raw_pose)
             assert (
                 actor._num_objs == num_objs_per_actor
             ), "Each given actor must have the same number of managed objects"
@@ -109,10 +114,8 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
         merged_scene_idxs = torch.concat(merged_scene_idxs)
         merged_actor = Actor.create_from_entities(objs, scene, merged_scene_idxs)
         merged_actor.name = name
-        merged_actor._builder_initial_pose = Pose.create(
-            torch.vstack(_builder_initial_poses)
-        )
-        scene.actors[merged_actor.name] = merged_actor
+        merged_actor.inital_pose = Pose.create(torch.vstack(_builder_initial_poses))
+        scene.actor_views[merged_actor.name] = merged_actor
         return merged_actor
 
     # -------------------------------------------------------------------------- #
@@ -224,7 +227,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
             if self.px_body_type == "static":
                 # NOTE (stao): usually _builder_initial_pose is just one pose, but for static objects in GPU sim we repeat it if necessary so it can be used
                 # as part of observations if needed
-                return self._builder_initial_pose
+                return self.inital_pose
             else:
                 if self.hidden:
                     return Pose.create(self.before_hide_pose)

--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -243,10 +243,10 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
             if not isinstance(arg1, torch.Tensor):
                 arg1 = vectorize_pose(arg1)
             if self.hidden:
-                self.before_hide_pose[self._scene._reset_mask] = arg1
+                self.before_hide_pose[self._scene._reset_mask[self._scene_idxs]] = arg1
             else:
                 self.px.cuda_rigid_body_data.torch()[
-                    self._body_data_index[self._scene._reset_mask], :7
+                    self._body_data_index[self._scene._reset_mask[self._scene_idxs]], :7
                 ] = arg1
         else:
             self._objs[0].pose = to_sapien_pose(arg1)

--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -252,6 +252,8 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
                     self._body_data_index[self._scene._reset_mask[self._scene_idxs]], :7
                 ] = arg1
         else:
+            # TODO (stao): some tasks use views over multiple objects but need to work on GPU sim so self._objs may not be across different scenes
+            # and this code won't work.
             self._objs[0].pose = to_sapien_pose(arg1)
 
     def set_pose(self, arg1: Union[Pose, sapien.Pose]) -> None:

--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -11,7 +11,7 @@ import sapien.render
 import torch
 
 from mani_skill.utils import sapien_utils
-from mani_skill.utils.structs.base import BaseStruct, PhysxRigidDynamicComponentStruct
+from mani_skill.utils.structs.base import PhysxRigidDynamicComponentStruct
 from mani_skill.utils.structs.pose import Pose, to_sapien_pose, vectorize_pose
 from mani_skill.utils.structs.types import Array
 

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -67,6 +67,9 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
     ] = field(default_factory=OrderedDict)
     """Maps a tuple of link names to pre-saved net contact force queries"""
 
+    def __str__(self):
+        return f"<{self.name}: struct of type {self.__class__}; managing {self._num_objs} {self._objs[0].__class__} objects>"
+
     @classmethod
     def create_from_physx_articulations(
         cls,
@@ -170,7 +173,6 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         for articulation in articulations:
             objs += articulation._objs
             merged_scene_idxs.append(articulation._scene_idxs)
-            del scene.articulations[articulation.name]
             assert (
                 articulation._num_objs == num_objs_per_actor
             ), "Each given articulation must have the same number of managed objects"
@@ -179,7 +181,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
             objs, scene, merged_scene_idxs, _merged=True
         )
         merged_articulation.name = name
-        scene.articulations[merged_articulation.name] = merged_articulation
+        scene.articulation_views[merged_articulation.name] = merged_articulation
         return merged_articulation
 
     # -------------------------------------------------------------------------- #

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -459,7 +459,8 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         if physx.is_gpu_enabled():
             arg1 = sapien_utils.to_tensor(arg1)
             self.px.cuda_articulation_qf.torch()[
-                self._data_index[self._scene._reset_mask], : self.max_dof
+                self._data_index[self._scene._reset_mask[self._scene_idxs]],
+                : self.max_dof,
             ] = arg1
         else:
             arg1 = sapien_utils.to_numpy(arg1)
@@ -497,7 +498,8 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         if physx.is_gpu_enabled():
             arg1 = sapien_utils.to_tensor(arg1)
             self.px.cuda_articulation_qpos.torch()[
-                self._data_index[self._scene._reset_mask], : self.max_dof
+                self._data_index[self._scene._reset_mask[self._scene_idxs]],
+                : self.max_dof,
             ] = arg1
         else:
             arg1 = sapien_utils.to_numpy(arg1)
@@ -519,7 +521,8 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         if physx.is_gpu_enabled():
             arg1 = sapien_utils.to_tensor(arg1)
             self.px.cuda_articulation_qvel.torch()[
-                self._data_index[self._scene._reset_mask], : self.max_dof
+                self._data_index[self._scene._reset_mask[self._scene_idxs]],
+                : self.max_dof,
             ] = arg1
         else:
             arg1 = sapien_utils.to_numpy(arg1)
@@ -536,7 +539,8 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         if physx.is_gpu_enabled():
             arg1 = sapien_utils.to_tensor(arg1)
             self.px.cuda_rigid_body_data.torch()[
-                self.root._body_data_index[self._scene._reset_mask], 10:13
+                self.root._body_data_index[self._scene._reset_mask[self._scene_idxs]],
+                10:13,
             ] = arg1
         else:
             arg1 = sapien_utils.to_numpy(arg1)
@@ -553,7 +557,8 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         if physx.is_gpu_enabled():
             arg1 = sapien_utils.to_tensor(arg1)
             self.px.cuda_rigid_body_data.torch()[
-                self.root._body_data_index[self._scene._reset_mask], 7:10
+                self.root._body_data_index[self._scene._reset_mask[self._scene_idxs]],
+                7:10,
             ] = arg1
         else:
             arg1 = sapien_utils.to_numpy(arg1)

--- a/mani_skill/utils/structs/link.py
+++ b/mani_skill/utils/structs/link.py
@@ -167,7 +167,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
     def pose(self, arg1: Union[Pose, sapien.Pose]) -> None:
         if physx.is_gpu_enabled():
             self.px.cuda_rigid_body_data.torch()[
-                self._body_data_index[self._scene._reset_mask], :7
+                self._body_data_index[self._scene._reset_mask[self._scene_idxs]], :7
             ] = vectorize_pose(arg1)
         else:
             self._objs[0].pose = to_sapien_pose(arg1)

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -111,11 +111,7 @@ class Pose:
             return cls(raw_pose=pose)
 
     def __getitem__(self, i):
-        if i >= len(self.raw_pose):
-            raise IndexError(
-                f"IndexError: index {i} is out of bounds for pose with batch size {len(self.raw_pose)}"
-            )
-        return Pose.create(self.raw_pose[i : i + 1, :])
+        return Pose.create(self.raw_pose[i])
 
     def __len__(self):
         return len(self.raw_pose)

--- a/mani_skill/utils/structs/types.py
+++ b/mani_skill/utils/structs/types.py
@@ -24,9 +24,11 @@ class GPUMemoryConfig:
     temp_buffer_capacity: int = 2**24
     """Increase this if you get 'PxgPinnedHostLinearMemoryAllocator: overflowing initial allocation size, increase capacity to at least %.' """
     max_rigid_contact_count: int = 2**19
+    """Increase this if you get 'Contact buffer overflow detected'"""
     max_rigid_patch_count: int = (
         2**18
     )  # 81920 is SAPIEN default but most tasks work with 2**18
+    """Increase this if you get 'Patch buffer overflow detected'"""
     heap_capacity: int = 2**26
     found_lost_pairs_capacity: int = (
         2**25

--- a/mani_skill/utils/wrappers/record.py
+++ b/mani_skill/utils/wrappers/record.py
@@ -312,6 +312,10 @@ class RecordEpisode(gym.Wrapper):
                     )
 
         obs, info = super().reset(*args, seed=seed, options=options, **kwargs)
+        if info["reconfigure"]:
+            # if we reconfigure, there is the possibility that state dictionary looks different now
+            # so trajectory buffer must be wiped
+            self._trajectory_buffer = None
 
         if self.save_trajectory:
             state_dict = self.base_env.get_state_dict()


### PR DESCRIPTION
- Add's the pick clutter task GPU version
- There is now actor and articulation views, which are the result of actor and articulation merging. Previously merging would delete the merged actors in favor of a single merged one which affects the state dict. This is no longer done now. Merged actors/articulations are simply references to data.
- Pose struct supports all indexing options of normal tensors now.
- Can easily merge all objects across all scenes, which can be useful for setting initial poses each episode start without more for loops.
- reset function returns a info object now with a reconfigure key, letting user know if a env reconfigured or not.
- new comments about tuning gpu memory configs
- _builder_initial_pose -> initial_pose as its an attribute users may want to use (it's fairly useful)
- fix bug occuring when setting any kind of sim data for merged actors/actor views (and articulations) where reset mask was not working as we did not further index that reset mask by which sub-scene indexes the object was actually a part of.

TODO still includes documenting task and adding reward function