### PR TITLE
use zeros_like in scene setup gpu to avoid nan

### DIFF
--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -689,10 +689,10 @@ class ManiSkillScene:
             articulation.set_pose(articulation.initial_pose)
 
         self.px.cuda_rigid_body_data.torch()[:, 7:] = (
-            self.px.cuda_rigid_body_data.torch()[:, 7:] * 0
+            torch.zeros_like(self.px.cuda_rigid_body_data.torch()[:, 7:])
         )  # zero out all velocities
         self.px.cuda_articulation_qvel.torch()[:, :] = (
-            self.px.cuda_articulation_qvel.torch() * 0
+            torch.zeros_like(self.px.cuda_articulation_qvel.torch())
         )  # zero out all q velocities
 
         self.px.gpu_apply_rigid_dynamic_data()


### PR DESCRIPTION
Here, px.cuda_rigid_body_data.torch() may contain NAN in certain cases. Just multiplying 0 won't eliminate the nan and it is better to set it to zero explicitly.