### PR TITLE
Dense Rews PullCube & LiftPegUpright

### DIFF
--- a/mani_skill/envs/tasks/tabletop/lift_peg_upright.py
+++ b/mani_skill/envs/tasks/tabletop/lift_peg_upright.py
@@ -90,14 +90,14 @@ class LiftPegUprightEnv(BaseEnv):
                 obj_pose=self.peg.pose.raw_pose,
             )
         return obs
-    
+
     def compute_dense_reward(self, obs: Any, action: Array, info: Dict):
         # rotation reward as cosine similarity between peg direction vectors
         # peg center of mass to end of peg, (1,0,0), rotated by peg pose rotation
         # dot product with its goal orientation: (0,0,1) or (0,0,-1)
         qmats = rotation_conversions.quaternion_to_matrix(self.peg.pose.q)
-        vec = torch.tensor([1.0,0,0], device=self.device)
-        goal_vec = torch.tensor([0,0,1.0], device=self.device)
+        vec = torch.tensor([1.0, 0, 0], device=self.device)
+        goal_vec = torch.tensor([0, 0, 1.0], device=self.device)
         rot_vec = (qmats @ vec).view(-1, 3)
         # abs since (0,0,-1) is also valid, values in [0,1]
         rot_rew = (rot_vec @ goal_vec).view(-1).abs()
@@ -112,12 +112,12 @@ class LiftPegUprightEnv(BaseEnv):
         # initially, we want to reach and grip peg
         to_grip_vec = self.peg.pose.p - self.agent.tcp.pose.p
         to_grip_dist = torch.linalg.norm(to_grip_vec, axis=1)
-        reaching_rew = 1 - torch.tanh(5*to_grip_dist)
+        reaching_rew = 1 - torch.tanh(5 * to_grip_dist)
         # reaching reward granted if gripping block
         reaching_rew[self.agent.is_grasping(self.peg)] = 1
         # weight reaching reward less
         reaching_rew = reaching_rew / 5
-        reward+=reaching_rew
+        reward += reaching_rew
 
         reward[info["success"]] = 3
         return reward

--- a/mani_skill/envs/tasks/tabletop/lift_peg_upright.py
+++ b/mani_skill/envs/tasks/tabletop/lift_peg_upright.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import numpy as np
 import torch
@@ -19,10 +19,6 @@ from mani_skill.utils.structs.types import Array
 
 @register_env("LiftPegUpright-v1", max_episode_steps=50)
 class LiftPegUprightEnv(BaseEnv):
-    SUPPORTED_REWARD_MODES = [
-        "sparse",
-        "none",
-    ]  # TODO add a denser reward for this later
     SUPPORTED_ROBOTS = ["panda", "xmate3_robotiq", "fetch"]
     agent: Union[Panda, Xmate3Robotiq, Fetch]
 
@@ -94,3 +90,38 @@ class LiftPegUprightEnv(BaseEnv):
                 obj_pose=self.peg.pose.raw_pose,
             )
         return obs
+    
+    def compute_dense_reward(self, obs: Any, action: Array, info: Dict):
+        # rotation reward as cosine similarity between peg direction vectors
+        # peg center of mass to end of peg, (1,0,0), rotated by peg pose rotation
+        # dot product with its goal orientation: (0,0,1) or (0,0,-1)
+        qmats = rotation_conversions.quaternion_to_matrix(self.peg.pose.q)
+        vec = torch.tensor([1.0,0,0], device=self.device)
+        goal_vec = torch.tensor([0,0,1.0], device=self.device)
+        rot_vec = (qmats @ vec).view(-1, 3)
+        # abs since (0,0,-1) is also valid, values in [0,1]
+        rot_rew = (rot_vec @ goal_vec).view(-1).abs()
+        reward = rot_rew
+
+        # position reward using common maniskill distance reward pattern
+        # giving reward in [0,1] for moving center of mass toward half length above table
+        z_dist = torch.abs(self.peg.pose.p[:, 2] - self.peg_half_length)
+        reward += 1 - torch.tanh(5 * z_dist)
+
+        # small reward to motivate initial reaching
+        # initially, we want to reach and grip peg
+        to_grip_vec = self.peg.pose.p - self.agent.tcp.pose.p
+        to_grip_dist = torch.linalg.norm(to_grip_vec, axis=1)
+        reaching_rew = 1 - torch.tanh(5*to_grip_dist)
+        # reaching reward granted if gripping block
+        reaching_rew[self.agent.is_grasping(self.peg)] = 1
+        # weight reaching reward less
+        reaching_rew = reaching_rew / 5
+        reward+=reaching_rew
+
+        reward[info["success"]] = 3
+        return reward
+
+    def compute_normalized_dense_reward(self, obs: Any, action: Array, info: Dict):
+        max_reward = 3.0
+        return self.compute_dense_reward(obs=obs, action=action, info=info) / max_reward

--- a/mani_skill/envs/tasks/tabletop/pull_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pull_cube.py
@@ -110,10 +110,12 @@ class PullCubeEnv(BaseEnv):
     def compute_dense_reward(self, obs: Any, action: Array, info: Dict):
         # grippers should close and pull from behind the cube, not grip it
         # distance to backside of cube (+ 2*0.005) sufficiently encourages this
-        tcp_pull_pos = self.obj.pose.p + torch.tensor([self.cube_half_size + 2*0.005, 0, 0], device=self.device)
+        tcp_pull_pos = self.obj.pose.p + torch.tensor(
+            [self.cube_half_size + 2 * 0.005, 0, 0], device=self.device
+        )
         tcp_to_pull_pose = tcp_pull_pos - self.agent.tcp.pose.p
         tcp_to_pull_pose_dist = torch.linalg.norm(tcp_to_pull_pose, axis=1)
-        reaching_reward = 1 - torch.tanh(5 * tcp_to_pull_pose_dist)  
+        reaching_reward = 1 - torch.tanh(5 * tcp_to_pull_pose_dist)
         reward = reaching_reward
 
         reached = tcp_to_pull_pose_dist < 0.01

--- a/mani_skill/envs/tasks/tabletop/pull_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pull_cube.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import numpy as np
 import torch
@@ -18,8 +18,6 @@ from mani_skill.utils.structs.types import Array
 
 @register_env("PullCube-v1", max_episode_steps=50)
 class PullCubeEnv(BaseEnv):
-    SUPPORTED_REWARD_MODES = ["sparse", "none"]
-
     SUPPORTED_ROBOTS = ["panda", "xmate3_robotiq", "fetch"]
     agent: Union[Panda, Xmate3Robotiq, Fetch]
     goal_radius = 0.1
@@ -109,27 +107,25 @@ class PullCubeEnv(BaseEnv):
             )
         return obs
 
-    # TODO (fix the reward for pull cube)
-    # def compute_dense_reward(self, obs: Any, action: Array, info: Dict):
-    #     tcp_push_pose = Pose.create_from_pq(
-    #         p=self.obj.pose.p
-    #         + torch.tensor([-self.cube_half_size - 0.005, 0, 0], device=self.device)
-    #     )
-    #     tcp_to_push_pose = tcp_push_pose.p - self.agent.tcp.pose.p
-    #     tcp_to_push_pose_dist = torch.linalg.norm(tcp_to_push_pose, axis=1)
-    #     reaching_reward = 1 - torch.tanh(5 * tcp_to_push_pose_dist)
-    #     reward = reaching_reward
+    def compute_dense_reward(self, obs: Any, action: Array, info: Dict):
+        # grippers should close and pull from behind the cube, not grip it
+        # distance to backside of cube (+ 2*0.005) sufficiently encourages this
+        tcp_pull_pos = self.obj.pose.p + torch.tensor([self.cube_half_size + 2*0.005, 0, 0], device=self.device)
+        tcp_to_pull_pose = tcp_pull_pos - self.agent.tcp.pose.p
+        tcp_to_pull_pose_dist = torch.linalg.norm(tcp_to_pull_pose, axis=1)
+        reaching_reward = 1 - torch.tanh(5 * tcp_to_pull_pose_dist)  
+        reward = reaching_reward
 
-    #     reached = tcp_to_push_pose_dist < 0.01
-    #     obj_to_goal_dist = torch.linalg.norm(
-    #         self.obj.pose.p[..., :2] - self.goal_region.pose.p[..., :2], axis=1
-    #     )
-    #     place_reward = 1 - torch.tanh(5 * obj_to_goal_dist)
-    #     reward += place_reward * reached
+        reached = tcp_to_pull_pose_dist < 0.01
+        obj_to_goal_dist = torch.linalg.norm(
+            self.obj.pose.p[..., :2] - self.goal_region.pose.p[..., :2], axis=1
+        )
+        place_reward = 1 - torch.tanh(5 * obj_to_goal_dist)
+        reward += place_reward * reached
 
-    #     reward[info["success"]] = 3
-    #     return reward
+        reward[info["success"]] = 3
+        return reward
 
-    # def compute_normalized_dense_reward(self, obs: Any, action: Array, info: Dict):
-    #     max_reward = 3.0
-    #     return self.compute_dense_reward(obs=obs, action=action, info=info) / max_reward
+    def compute_normalized_dense_reward(self, obs: Any, action: Array, info: Dict):
+        max_reward = 3.0
+        return self.compute_dense_reward(obs=obs, action=action, info=info) / max_reward


### PR DESCRIPTION
Dense Rewards added for PullCube & LiftPegUpright Envs

PullCube dense reward is mirror of PushCube, difference is reaching reward on opposite side of cube

LiftPegUpright dense reward is sum of rotation reward (implemented as cosine similarity of unit vector from peg center of mass toward end of peg and it's goal orientation -see implementation comments for details) + center of mass distance reward + reaching/gripping reward

bash command to re-create experiments with PPO below: 
PullCube:
for i in {1..3}; do python ppo.py --env_id="PullCube-v1" --exp-name="pullcubeseed${i}" --num_envs=2048 \\
--update_epochs=8 --num_minibatches=32   --total_timesteps=4_000_000 --eval_freq=10 --num-steps=20 \\
--seed=${i} --gamma=0.8; done

LiftPegUpright:
for i in {1..3}; do python ppo.py --env_id="LiftPegUpright-v1" --exp-name="liftpegseed${i}" --num_envs=2048 \\
--update_epochs=8 --num_minibatches=32 --total_timesteps=9_000_000 --eval_freq=10 --num-steps=20 \\
--seed=${i} --gamma=0.9; done

![image](https://github.com/haosulab/ManiSkill/assets/115660089/f98051dd-7c96-4208-98b9-93bb6bca9744)
![image](https://github.com/haosulab/ManiSkill/assets/115660089/7c48bb28-59d9-4fd5-b361-3a8c10d83c47)

Comparison between pullcube and pushcube: 

pushcube ran as default, with more steps to overshoot convergence

pushcube:
for i in {1..3}; do python ppo.py --env_id="PushCube-v1" --exp-name="pushcubeseed${i}" --num_envs=2048 \\
--update_epochs=8 --num_minibatches=32   --total_timesteps=4_000_000 --eval_freq=10 --num-steps=20 \\
--seed=${i} --gamma=0.8; done

![image](https://github.com/haosulab/ManiSkill/assets/115660089/c593fb1d-2482-4441-8120-34a35fb60304)


https://github.com/haosulab/ManiSkill/assets/115660089/46561965-20f6-4cf0-b0af-0bd54bcf9391


https://github.com/haosulab/ManiSkill/assets/115660089/49538553-2686-46d6-829a-d34d764eadb8


