### PR TITLE
[Feature] Expose articulation acceleration values

### DIFF
--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -688,11 +688,11 @@ class ManiSkillScene:
         for articulation in self.articulations.values():
             articulation.set_pose(articulation.initial_pose)
 
-        self.px.cuda_rigid_body_data.torch()[:, 7:] = (
-            torch.zeros_like(self.px.cuda_rigid_body_data.torch()[:, 7:])
+        self.px.cuda_rigid_body_data.torch()[:, 7:] = torch.zeros_like(
+            self.px.cuda_rigid_body_data.torch()[:, 7:]
         )  # zero out all velocities
-        self.px.cuda_articulation_qvel.torch()[:, :] = (
-            torch.zeros_like(self.px.cuda_articulation_qvel.torch())
+        self.px.cuda_articulation_qvel.torch()[:, :] = torch.zeros_like(
+            self.px.cuda_articulation_qvel.torch()
         )  # zero out all q velocities
 
         self.px.gpu_apply_rigid_dynamic_data()
@@ -736,11 +736,9 @@ class ManiSkillScene:
             self.px.gpu_fetch_articulation_link_velocity()
             self.px.gpu_fetch_articulation_qpos()
             self.px.gpu_fetch_articulation_qvel()
+            # self.px.gpu_fetch_articulation_qacc()
             self.px.gpu_fetch_articulation_target_qpos()
             self.px.gpu_fetch_articulation_target_qvel()
-
-            # unused fetches
-            # self.px.gpu_fetch_articulation_qacc()
 
         self._needs_fetch = False
 

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -736,7 +736,7 @@ class ManiSkillScene:
             self.px.gpu_fetch_articulation_link_velocity()
             self.px.gpu_fetch_articulation_qpos()
             self.px.gpu_fetch_articulation_qvel()
-            # self.px.gpu_fetch_articulation_qacc()
+            self.px.gpu_fetch_articulation_qacc()
             self.px.gpu_fetch_articulation_target_qpos()
             self.px.gpu_fetch_articulation_target_qvel()
 

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -2,7 +2,6 @@ import argparse
 
 import gymnasium as gym
 import numpy as np
-import torch
 
 from mani_skill.envs.sapien_env import BaseEnv
 from mani_skill.utils.wrappers import RecordEpisode

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -2,6 +2,7 @@ import argparse
 
 import gymnasium as gym
 import numpy as np
+import torch
 
 from mani_skill.envs.sapien_env import BaseEnv
 from mani_skill.utils.wrappers import RecordEpisode
@@ -81,7 +82,7 @@ def main(args):
         viewer = env.render()
         viewer.paused = args.pause
         env.render()
-
+    robot = env.agent.robot
     while True:
         action = env.action_space.sample()
         obs, reward, terminated, truncated, info = env.step(action)
@@ -94,7 +95,9 @@ def main(args):
             env.render()
 
         if args.render_mode is None or args.render_mode != "human":
-            if terminated or truncated:
+            if args.num_envs > 1 and torch.logical_or(terminated, truncated).any():
+                break
+            if args.num_envs == 1 and (terminated or truncated):
                 break
     env.close()
 

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -94,9 +94,10 @@ def main(args):
             env.render()
 
         if args.render_mode is None or args.render_mode != "human":
-            if args.num_envs > 1 and torch.logical_or(terminated, truncated).any():
-                break
-            if args.num_envs == 1 and (terminated or truncated):
+            # TODO (stao): add fix for gym.make envs using cpu time limit wrappers to remove the code below
+            if isinstance(truncated, bool):
+                truncated = torch.tensor([truncated], device=env.device)
+            if torch.logical_or(terminated, truncated).any():
                 break
     env.close()
 

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -82,7 +82,6 @@ def main(args):
         viewer = env.render()
         viewer.paused = args.pause
         env.render()
-    robot = env.agent.robot
     while True:
         action = env.action_space.sample()
         obs, reward, terminated, truncated, info = env.step(action)

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -536,11 +536,15 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
     def pose(self, arg1: Union[Pose, sapien.Pose]) -> None:
         self.root_pose = arg1
 
-    # @property
-    # def qacc(self) -> numpy.ndarray[numpy.float32, _Shape[m, 1]]:
-    #     """
-    #     :type: numpy.ndarray[numpy.float32, _Shape[m, 1]]
-    #     """
+    @property
+    def qacc(self):
+        if physx.is_gpu_enabled():
+            return self.px.cuda_articulation_qacc.torch()[
+                self._data_index, : self.max_dof
+            ]
+        else:
+            return torch.from_numpy(self._objs[0].qacc[None, :])
+
     # @qacc.setter
     # def qacc(self, arg1: numpy.ndarray[numpy.float32, _Shape[m, 1]]) -> None:
     #     pass


### PR DESCRIPTION
articulation.qacc gives joint acceleration values now. It is not part of env observations by default as it is not often used.

In the future a lazy buffer mechanism should be added to avoid fetching some quantities all the time if they aren't used.