### PR TITLE
[BugFix] Replaces the default gymnasium timelimit wrapper with a batched/torch version when gym.make is used

### DIFF
--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -61,9 +61,9 @@ def main(args):
         num_envs=args.num_envs,
         sim_backend=args.sim_backend,
         parallel_gui_render_enabled=parallel_gui_render_enabled,
+        max_episode_steps=20,
         **args.env_kwargs
     )
-
     record_dir = args.record_dir
     if record_dir:
         record_dir = record_dir.format(env_id=args.env_id)
@@ -94,7 +94,7 @@ def main(args):
             env.render()
 
         if args.render_mode is None or args.render_mode != "human":
-            if terminated or truncated:
+            if (terminated | truncated).any():
                 break
     env.close()
 

--- a/mani_skill/utils/gym_utils.py
+++ b/mani_skill/utils/gym_utils.py
@@ -19,10 +19,12 @@ def find_max_episode_steps_value(env):
     while cur is not None:
         if hasattr(cur, "max_episode_steps"):
             return cur.max_episode_steps
+        if hasattr(cur, "_max_episode_steps"):
+            return cur._max_episode_steps
         if cur.spec is not None and cur.spec.max_episode_steps is not None:
             return cur.spec.max_episode_steps
         if hasattr(cur, "env"):
-            cur = env.env
+            cur = cur.env
         else:
             cur = None
     return None

--- a/mani_skill/utils/registration.py
+++ b/mani_skill/utils/registration.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import sys
 from copy import deepcopy
 from functools import partial
 from typing import TYPE_CHECKING, Dict, Type
 
 import gymnasium as gym
 from gymnasium.envs.registration import EnvSpec as GymEnvSpec
+from gymnasium.envs.registration import WrapperSpec
 
 from mani_skill import logger
 from mani_skill.vector.wrappers.gymnasium import ManiSkillVectorEnv
@@ -66,19 +68,50 @@ def register(
     )
 
 
-def make(env_id, enable_segmentation=False, **kwargs):
+class TimeLimitWrapper(gym.Wrapper):
+    """like the standard gymnasium timelimit wrapper but fixes truncated variable to be a torch tensor and batched"""
+
+    def __init__(self, env: gym.Env, max_episode_steps: int):
+        super().__init__(env)
+        prev_frame_locals = sys._getframe(1).f_locals
+        frame = sys._getframe(1)
+        # check for user supplied max_episode_steps during gym.make calls
+        if (
+            frame.f_code.co_name == "make"
+            and "max_episode_steps" in prev_frame_locals
+            and prev_frame_locals["max_episode_steps"] is not None
+        ):
+            max_episode_steps = prev_frame_locals["max_episode_steps"]
+            # do some wrapper surgery to remove the previous timelimit wrapper
+            # with gymnasium 0.29.1, this will remove the timelimit wrapper and nothing else.
+            curr_env = env
+            while curr_env is not None:
+                if isinstance(curr_env, gym.wrappers.TimeLimit):
+                    self.env = curr_env.env
+                    break
+        self._max_episode_steps = max_episode_steps
+
+    @property
+    def base_env(self) -> BaseEnv:
+        return self.env.unwrapped
+
+    def step(self, action):
+        observation, reward, terminated, truncated, info = self.env.step(action)
+        truncated = self.base_env.elapsed_steps >= self._max_episode_steps
+        return observation, reward, terminated, truncated, info
+
+
+def make(env_id, **kwargs):
     """Instantiate a ManiSkill environment.
 
     Args:
         env_id (str): Environment ID.
         as_gym (bool, optional): Add TimeLimit wrapper as gym.
-        enable_segmentation (bool, optional): Whether to include Segmentation in observations.
         **kwargs: Keyword arguments to pass to the environment.
     """
     if env_id not in REGISTERED_ENVS:
         raise KeyError("Env {} not found in registry".format(env_id))
     env_spec = REGISTERED_ENVS[env_id]
-
     env = env_spec.make(**kwargs)
     return env
 
@@ -122,7 +155,7 @@ def register_env(uid: str, max_episode_steps=None, override=False, **kwargs):
                 logger.warn(f"Env {uid} is already registered. Skip registration.")
                 return cls
 
-        # Register for ManiSkil2
+        # Register for ManiSkill
         register(
             uid,
             cls,
@@ -138,6 +171,13 @@ def register_env(uid: str, max_episode_steps=None, override=False, **kwargs):
             max_episode_steps=max_episode_steps,
             disable_env_checker=True,  # Temporary solution as we allow empty observation spaces
             kwargs=deepcopy(kwargs),
+            additional_wrappers=[
+                WrapperSpec(
+                    "MSTimeLimit",
+                    entry_point="mani_skill.utils.registration:TimeLimitWrapper",
+                    kwargs=dict(max_episode_steps=max_episode_steps),
+                )
+            ],
         )
 
         return cls

--- a/mani_skill/utils/registration.py
+++ b/mani_skill/utils/registration.py
@@ -114,9 +114,8 @@ def make(env_id, **kwargs):
 
 
 def make_vec(env_id, **kwargs):
-    max_episode_steps = kwargs.pop("max_episode_steps", None)
-    env = make(env_id, **kwargs)
-    env = ManiSkillVectorEnv(env, max_episode_steps=max_episode_steps)
+    env = gym.make(env_id, **kwargs)
+    env = ManiSkillVectorEnv(env)
     return env
 
 

--- a/mani_skill/utils/registration.py
+++ b/mani_skill/utils/registration.py
@@ -76,12 +76,9 @@ class TimeLimitWrapper(gym.Wrapper):
         prev_frame_locals = sys._getframe(1).f_locals
         frame = sys._getframe(1)
         # check for user supplied max_episode_steps during gym.make calls
-        if (
-            frame.f_code.co_name == "make"
-            and "max_episode_steps" in prev_frame_locals
-            and prev_frame_locals["max_episode_steps"] is not None
-        ):
-            max_episode_steps = prev_frame_locals["max_episode_steps"]
+        if frame.f_code.co_name == "make" and "max_episode_steps" in prev_frame_locals:
+            if prev_frame_locals["max_episode_steps"] is not None:
+                max_episode_steps = prev_frame_locals["max_episode_steps"]
             # do some wrapper surgery to remove the previous timelimit wrapper
             # with gymnasium 0.29.1, this will remove the timelimit wrapper and nothing else.
             curr_env = env

--- a/mani_skill/utils/structs/link.py
+++ b/mani_skill/utils/structs/link.py
@@ -207,7 +207,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
                 raw_pose = new_pose
             return Pose.create(raw_pose)
         else:
-            return Pose.create([obj.pose for obj in self._objs])
+            return Pose.create([obj.entity_pose for obj in self._objs])
 
     @pose.setter
     def pose(self, arg1: Union[Pose, sapien.Pose, Array]) -> None:

--- a/mani_skill/utils/wrappers/record.py
+++ b/mani_skill/utils/wrappers/record.py
@@ -408,13 +408,6 @@ class RecordEpisode(gym.Wrapper):
         obs, rew, terminated, truncated, info = super().step(action)
 
         if self.save_trajectory:
-            if (
-                isinstance(truncated, bool)
-                and self.num_envs > 1
-                and self.max_episode_steps is not None
-            ):
-                # this fixes the issue where gymnasium applies a non-batched timelimit wrapper
-                truncated = self.base_env.elapsed_steps >= self.max_episode_steps
             state_dict = self.base_env.get_state_dict()
             if self.record_env_state:
                 self._trajectory_buffer.state = common.append_dict_array(

--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -29,9 +29,6 @@ class ManiSkillVectorEnv(VectorEnv):
             the task reaching a success or fail state as defined in a task's evaluation function. Default is False, meaning there is early stop in
             episode rollouts. If set to True, this would generally for situations where you may want to model a task as infinite horizon where a task
             stops only due to the timelimit.
-        handle_truncations (bool): Whether this wrapper handles truncations based on the given max_episode_steps or whatever
-            max_episode_steps is defined in the environment's spec. If this is True it will override any truncation values set by
-            previous wrappers. Default is True.
     """
 
     def __init__(
@@ -39,9 +36,7 @@ class ManiSkillVectorEnv(VectorEnv):
         env: Union[BaseEnv, str],
         num_envs: int = None,
         auto_reset: bool = True,
-        max_episode_steps: int = None,
         ignore_terminations: bool = False,
-        handle_truncations: bool = True,
         **kwargs,
     ):
         if isinstance(env, str):
@@ -51,21 +46,11 @@ class ManiSkillVectorEnv(VectorEnv):
             num_envs = self.base_env.num_envs
         self.auto_reset = auto_reset
         self.ignore_terminations = ignore_terminations
-        self.handle_truncations = handle_truncations
         super().__init__(
             num_envs, self._env.single_observation_space, self._env.single_action_space
         )
 
         self.returns = torch.zeros(self.num_envs, device=self.base_env.device)
-        self.max_episode_steps = max_episode_steps
-        if (
-            self.max_episode_steps is None
-            and self.base_env.spec.max_episode_steps is not None
-        ):
-            self.max_episode_steps = self.base_env.spec.max_episode_steps
-        if self.max_episode_steps is None:
-            # search wrappers to find where max episode steps may have been defined
-            self.max_episode_steps = gym_utils.find_max_episode_steps_value(env)
 
     @property
     def device(self):
@@ -103,11 +88,6 @@ class ManiSkillVectorEnv(VectorEnv):
 
         infos["episode"] = dict(r=self.returns)
 
-        # fix issue with gymnasium replacing truncations with a single bool
-        if self.handle_truncations and self.max_episode_steps is not None:
-            truncations: torch.Tensor = (
-                self.base_env.elapsed_steps >= self.max_episode_steps
-            )
         if isinstance(terminations, bool):
             terminations = torch.tensor([terminations], device=self.device)
         if self.ignore_terminations:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "rtree",
         "imageio",
         "imageio[ffmpeg]",
-        "mplib>=0.1.1;platform_system=='Linux'",
+        "mplib==0.1.1;platform_system=='Linux'",
         "fast_kinematics==0.2.2;platform_system=='Linux'",
         "IPython",
         "huggingface_hub",  # we use HF to version control some assets/datasets more easily

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -40,27 +40,27 @@ def test_envs_obs_modes(env_id, obs_mode):
     action_space = env.action_space
     for _ in range(5):
         obs, rew, terminated, truncated, info = env.step(action_space.sample())
-    assert_isinstance(obs, [np.ndarray, bool, float, int])
-    assert_isinstance(rew, float)
-    assert_isinstance(terminated, bool)
-    assert_isinstance(truncated, bool)
-    assert_isinstance(info, [np.ndarray, bool, float, int])
-    if obs_mode == "rgbd":
-        for cam in obs["sensor_data"].keys():
-            assert obs["sensor_data"][cam]["rgb"].shape == (128, 128, 3)
-            assert obs["sensor_data"][cam]["depth"].shape == (128, 128, 1)
-            assert obs["sensor_data"][cam]["depth"].dtype == np.int16
-            assert obs["sensor_data"][cam]["segmentation"].shape == (128, 128, 1)
-            assert obs["sensor_data"][cam]["segmentation"].dtype == np.int16
-            assert obs["sensor_param"][cam]["extrinsic_cv"].shape == (3, 4)
-            assert obs["sensor_param"][cam]["intrinsic_cv"].shape == (3, 3)
-            assert obs["sensor_param"][cam]["cam2world_gl"].shape == (4, 4)
-    elif obs_mode == "pointcloud":
-        num_pts = len(obs["pointcloud"]["xyzw"])
-        assert obs["pointcloud"]["xyzw"].shape == (num_pts, 4)
-        assert obs["pointcloud"]["rgb"].shape == (num_pts, 3)
-        assert obs["pointcloud"]["segmentation"].shape == (num_pts, 1)
-        assert obs["pointcloud"]["segmentation"].dtype == np.int16
+        assert_isinstance(obs, [np.ndarray, bool, float, int])
+        assert_isinstance(rew, float)
+        assert_isinstance(terminated, bool)
+        assert_isinstance(truncated, bool)
+        assert_isinstance(info, [np.ndarray, bool, float, int])
+        if obs_mode == "rgbd":
+            for cam in obs["sensor_data"].keys():
+                assert obs["sensor_data"][cam]["rgb"].shape == (128, 128, 3)
+                assert obs["sensor_data"][cam]["depth"].shape == (128, 128, 1)
+                assert obs["sensor_data"][cam]["depth"].dtype == np.int16
+                assert obs["sensor_data"][cam]["segmentation"].shape == (128, 128, 1)
+                assert obs["sensor_data"][cam]["segmentation"].dtype == np.int16
+                assert obs["sensor_param"][cam]["extrinsic_cv"].shape == (3, 4)
+                assert obs["sensor_param"][cam]["intrinsic_cv"].shape == (3, 3)
+                assert obs["sensor_param"][cam]["cam2world_gl"].shape == (4, 4)
+        elif obs_mode == "pointcloud":
+            num_pts = len(obs["pointcloud"]["xyzw"])
+            assert obs["pointcloud"]["xyzw"].shape == (num_pts, 4)
+            assert obs["pointcloud"]["rgb"].shape == (num_pts, 3)
+            assert obs["pointcloud"]["segmentation"].shape == (num_pts, 1)
+            assert obs["pointcloud"]["segmentation"].dtype == np.int16
     env.close()
     del env
 
@@ -75,27 +75,27 @@ def test_envs_obs_modes_without_cpu_gym_wrapper(env_id, obs_mode):
     action_space = env.action_space
     for _ in range(5):
         obs, rew, terminated, truncated, info = env.step(action_space.sample())
-    assert_isinstance(obs, [torch.Tensor])
-    assert_isinstance(rew, torch.Tensor)
-    assert_isinstance(terminated, torch.Tensor)
-    assert_isinstance(truncated, torch.Tensor)
-    assert_isinstance(info, torch.Tensor)
-    if obs_mode == "rgbd":
-        for cam in obs["sensor_data"].keys():
-            assert obs["sensor_data"][cam]["rgb"].shape == (1, 128, 128, 3)
-            assert obs["sensor_data"][cam]["depth"].shape == (1, 128, 128, 1)
-            assert obs["sensor_data"][cam]["depth"].dtype == torch.int16
-            assert obs["sensor_data"][cam]["segmentation"].shape == (1, 128, 128, 1)
-            assert obs["sensor_data"][cam]["segmentation"].dtype == torch.int16
-            assert obs["sensor_param"][cam]["extrinsic_cv"].shape == (1, 3, 4)
-            assert obs["sensor_param"][cam]["intrinsic_cv"].shape == (1, 3, 3)
-            assert obs["sensor_param"][cam]["cam2world_gl"].shape == (1, 4, 4)
-    elif obs_mode == "pointcloud":
-        num_pts = len(obs["pointcloud"]["xyzw"][0])
-        assert obs["pointcloud"]["xyzw"].shape == (1, num_pts, 4)
-        assert obs["pointcloud"]["rgb"].shape == (1, num_pts, 3)
-        assert obs["pointcloud"]["segmentation"].shape == (1, num_pts, 1)
-        assert obs["pointcloud"]["segmentation"].dtype == torch.int16
+        assert_isinstance(obs, [torch.Tensor])
+        assert_isinstance(rew, torch.Tensor)
+        assert_isinstance(terminated, torch.Tensor)
+        assert_isinstance(truncated, torch.Tensor)
+        assert_isinstance(info, torch.Tensor)
+        if obs_mode == "rgbd":
+            for cam in obs["sensor_data"].keys():
+                assert obs["sensor_data"][cam]["rgb"].shape == (1, 128, 128, 3)
+                assert obs["sensor_data"][cam]["depth"].shape == (1, 128, 128, 1)
+                assert obs["sensor_data"][cam]["depth"].dtype == torch.int16
+                assert obs["sensor_data"][cam]["segmentation"].shape == (1, 128, 128, 1)
+                assert obs["sensor_data"][cam]["segmentation"].dtype == torch.int16
+                assert obs["sensor_param"][cam]["extrinsic_cv"].shape == (1, 3, 4)
+                assert obs["sensor_param"][cam]["intrinsic_cv"].shape == (1, 3, 3)
+                assert obs["sensor_param"][cam]["cam2world_gl"].shape == (1, 4, 4)
+        elif obs_mode == "pointcloud":
+            num_pts = len(obs["pointcloud"]["xyzw"][0])
+            assert obs["pointcloud"]["xyzw"].shape == (1, num_pts, 4)
+            assert obs["pointcloud"]["rgb"].shape == (1, num_pts, 3)
+            assert obs["pointcloud"]["segmentation"].shape == (1, num_pts, 1)
+            assert obs["pointcloud"]["segmentation"].dtype == torch.int16
     env.close()
     del env
 
@@ -205,3 +205,18 @@ def test_multi_agent(env_id):
         env.step(action_space.sample())
     env.close()
     del env
+
+
+def test_envs_time_limit_typing():
+    env = gym.make("PickCube-v1", max_episode_steps=5)
+    env.reset()
+    for _ in range(5):
+        obs, rew, terminated, truncated, info = env.step(env.action_space.sample())
+        assert_isinstance(terminated, torch.Tensor)
+        assert_isinstance(truncated, torch.Tensor)
+    env = gym.make("PickCube-v1")  # should use default registered max episode steps
+    env.reset()
+    for _ in range(50):
+        obs, rew, terminated, truncated, info = env.step(env.action_space.sample())
+        assert_isinstance(terminated, torch.Tensor)
+        assert_isinstance(truncated, torch.Tensor)

--- a/tests/test_gpu_envs.py
+++ b/tests/test_gpu_envs.py
@@ -292,11 +292,10 @@ def test_partial_resets(env_id):
 
 
 @pytest.mark.gpu_sim
-@pytest.mark.parametrize("env_id", STATIONARY_ENV_IDS[:1])
-def test_timelimits(env_id):
+def test_timelimits():
     """Test that the vec env batches the truncated variable correctly"""
     env = gym.make_vec(
-        env_id,
+        "PickCube-v1",
         num_envs=16,
         vectorization_mode="custom",
         vector_kwargs=dict(sim_cfg=LOW_MEM_SIM_CFG),


### PR DESCRIPTION
Bit of a hacky solution to replace an already used timelimit wrapper with a new one given how gymnasium works. But this now ensures the `truncated` return value is always a batched torch tensor.