### PR TITLE
Fix issue when trying to delete actor from scene

### DIFF
--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -129,13 +129,13 @@ class ManiSkillScene:
     ):
         return physx.PhysxMaterial(static_friction, dynamic_friction, restitution)
 
-    def remove_actor(self, actor : Actor):
+    def remove_actor(self, actor: Actor):
         if physx.is_gpu_enabled():
             raise NotImplementedError(
                 "Cannot remove actors after creating them in GPU sim at the moment"
             )
         else:
-            entities = [l for l in actor_objs]
+            entities = [l for l in actor._objs]
             for e in entities:
                 self.sub_scenes[0].remove_entity(e)
 

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -135,9 +135,7 @@ class ManiSkillScene:
                 "Cannot remove actors after creating them in GPU sim at the moment"
             )
         else:
-            entities = [l for l in actor._objs]
-            for e in entities:
-                self.sub_scenes[0].remove_entity(e)
+            self.sub_scenes[0].remove_entity(e for e in actor._objs)
 
     def remove_articulation(self, articulation: Articulation):
         if physx.is_gpu_enabled():
@@ -145,9 +143,7 @@ class ManiSkillScene:
                 "Cannot remove articulations after creating them in GPU sim at the moment"
             )
         else:
-            entities = [l.entity for l in articulation._objs[0].links]
-            for e in entities:
-                self.sub_scenes[0].remove_entity(e)
+            self.sub_scenes[0].remove_entity(l.entity for l in articulation._objs[0].links)
 
     def add_camera(
         self,

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -129,13 +129,15 @@ class ManiSkillScene:
     ):
         return physx.PhysxMaterial(static_friction, dynamic_friction, restitution)
 
-    def remove_actor(self, actor):
+    def remove_actor(self, actor : Actor):
         if physx.is_gpu_enabled():
             raise NotImplementedError(
                 "Cannot remove actors after creating them in GPU sim at the moment"
             )
         else:
-            self.sub_scenes[0].remove_entity(actor)
+            entities = [l for l in actor_objs]
+            for e in entities:
+                self.sub_scenes[0].remove_entity(e)
 
     def remove_articulation(self, articulation: Articulation):
         if physx.is_gpu_enabled():


### PR DESCRIPTION
When trying to call the `remove_actor` function on a created actor, I obtained the following error : 
```
TypeError: remove_entity(): incompatible function arguments. The following argument types are supported:
    1. (self: sapien.pysapien.Scene, entity: sapien.pysapien.Entity) -> None

Invoked with: <sapien.wrapper.scene.Scene object at 0x777ea016f4d0>, <distractor_0: struct of type <class 'mani_skill.utils.structs.actor.Actor'>; managing 1 <class 'sapien.pysapien.Entity'> objects>
```
I adapted the code in order to get all entities related to the actor in order to delete them, as it was already done for the articulations.