### PR TITLE
Remove unnecessary global declaration

### DIFF
--- a/mani_skill/utils/building/actors/ycb.py
+++ b/mani_skill/utils/building/actors/ycb.py
@@ -15,7 +15,6 @@ def _load_ycb_dataset():
 def get_ycb_builder(
     scene: ManiSkillScene, id: str, add_collision: bool = True, add_visual: bool = True
 ):
-    global YCB_DATASET
     if "YCB" not in YCB_DATASET:
         _load_ycb_dataset()
     model_db = YCB_DATASET["model_data"]


### PR DESCRIPTION
Because YCB_DATASET is marked as global in `_load_ycb_dataset` it is not necessary to mark it as global in get_ycb_builder