### PR TITLE
[Docs] Add docstring to documentation generation with Sphinx Napoleon

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,9 @@ build:
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -f -o docs/source/user_guide/reference/autogendocs mani_skill -d 2 
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -29,4 +32,10 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: docs/requirements.txt
+     - requirements: docs/requirements.txt
+       method: pip
+       path: .
+       # Install packages required to build the documentation. 
+       # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc 
+       extra_requirements:
+         - dev

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 build
+source/user_guide/reference/autogendocs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,7 @@ sphinx-subfigure
 sphinxcontrib-video
 sphinx-togglebutton
 sphinx_design
+# For sphinx.ext.autodoc to correctly generate api documentation
+torch
+torchvision
+torchaudio

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "myst_parser",
     "sphinx_subfigure",
@@ -71,3 +72,6 @@ html_static_path = ['_static']
 
 autodoc_typehints = "description"
 autodoc_typehints_description_target = "all"
+
+# Other autodoc configurations
+autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']

--- a/docs/source/user_guide/reference/index.md
+++ b/docs/source/user_guide/reference/index.md
@@ -5,11 +5,6 @@ In the beta release we are still in the process of documenting all of the functi
 Subpackages:
 
 ```{toctree}
-:titlesonly:
-:maxdepth: 1
-   
-mani_skill.envs.sapien_env
-
-mani_skill.utils.common
-mani_skill.utils.sapien_utils
+:maxdepth: 3
+autogendocs/mani_skill
 ```


### PR DESCRIPTION
Description: Add documentation generation from docstring.

Question:
Per [sphinx-apidoc's documentation](https://arc.net/l/quote/zaqlvkjx), building the documentation requires all required dependencies as if developing the code. Else, complete documentation will not be generated. Is there a way to test the edits in `.readthedocs.yaml` to see if all required dependencies are installed and that documentations are successfully generated?