### PR TITLE
[Feature] Updated TD-MPC2 evaluation and fixed some bugs

### DIFF
--- a/examples/baselines/tdmpc2/common/parser.py
+++ b/examples/baselines/tdmpc2/common/parser.py
@@ -60,11 +60,17 @@ def parse_cfg(cfg: OmegaConf) -> OmegaConf:
 	cfg.env_cfg.env_id = cfg.eval_env_cfg.env_id = cfg.env_id
 	cfg.env_cfg.obs_mode = cfg.eval_env_cfg.obs_mode = cfg.obs # state or rgb
 	cfg.env_cfg.reward_mode = cfg.eval_env_cfg.reward_mode = 'normalized_dense'
-	cfg.env_cfg.num_envs = cfg.eval_env_cfg.num_envs = cfg.num_envs # eval_env num_envs can change (tbd)
+	cfg.env_cfg.num_envs = cfg.num_envs
+	cfg.eval_env_cfg.num_envs = cfg.num_eval_envs
 	if cfg.num_envs == 1:
-		cfg.env_cfg.sim_backend = cfg.eval_env_cfg.sim_backend = 'cpu'
+		cfg.env_cfg.sim_backend = 'cpu'
 	else:
-		cfg.env_cfg.sim_backend = cfg.eval_env_cfg.sim_backend = 'gpu'
+		cfg.env_cfg.sim_backend = 'gpu'
+	
+	if cfg.num_eval_envs == 1:
+		cfg.eval_env_cfg.sim_backend = 'cpu'
+	else:
+		cfg.eval_env_cfg.sim_backend = 'gpu'
 	
 	cfg.eval_env_cfg.num_eval_episodes = cfg.eval_episodes
 		

--- a/examples/baselines/tdmpc2/config.yaml
+++ b/examples/baselines/tdmpc2/config.yaml
@@ -6,6 +6,7 @@ env_id: PushCube-v1
 obs: state # or rgb
 control_mode: default # or pd_joint_delta_pos or pd_ee_delta_pose
 num_envs: 32
+num_eval_envs: 4
 render_mode: rgb_array # ['rgb_array' for quality, or 'sensors' for speed]
 render_size: 64
 setting_tag: none # ['none', 'walltime_efficient', 'sample_efficient', ...] for wandb tags

--- a/examples/baselines/tdmpc2/envs/__init__.py
+++ b/examples/baselines/tdmpc2/envs/__init__.py
@@ -12,16 +12,16 @@ try:
 	from envs.maniskill import make_envs as make_maniskill_vec_env
 except:
 	make_maniskill_env = missing_dependencies
-
+from mani_skill.utils import gym_utils
 
 warnings.filterwarnings('ignore', category=DeprecationWarning)
 
-def make_envs(cfg):
+def make_envs(cfg, num_envs):
 	from envs.maniskill import make_envs as make_maniskill_vec_env
-	env = make_maniskill_vec_env(cfg)
+	env = make_maniskill_vec_env(cfg, num_envs)
 
 	if cfg.get('obs', 'state') == 'rgb':
-		env = PixelWrapper(cfg, env)
+		env = PixelWrapper(cfg, env, num_envs)
 
 	try: # Dict
 		cfg.obs_shape = {k: v.shape[1:] for k, v in env.observation_space.spaces.items()}

--- a/examples/baselines/tdmpc2/envs/maniskill.py
+++ b/examples/baselines/tdmpc2/envs/maniskill.py
@@ -1,10 +1,11 @@
 import gymnasium as gym
 import numpy as np
 from mani_skill.vector.wrappers.gymnasium import ManiSkillVectorEnv
+from mani_skill.utils import gym_utils
 
 import mani_skill.envs
 
-def make_envs(cfg):
+def make_envs(cfg, num_envs):
 	"""
 	Make ManiSkill3 environment.
 	"""
@@ -15,7 +16,7 @@ def make_envs(cfg):
 			obs_mode=cfg.obs, 
 			render_mode=cfg.render_mode,
 			sensor_configs=dict(width=cfg.render_size, height=cfg.render_size),
-			num_envs=cfg.num_envs
+			num_envs=num_envs
 		)
 	else:
 		env = gym.make(
@@ -24,11 +25,9 @@ def make_envs(cfg):
 			control_mode=cfg.control_mode,
 			render_mode=cfg.render_mode,
 			sensor_configs=dict(width=cfg.render_size, height=cfg.render_size),
-			num_envs=cfg.num_envs
+			num_envs=num_envs
 		)
-
 	cfg.env_cfg.control_mode = cfg.eval_env_cfg.control_mode = env.control_mode
-	env.max_episode_steps = env._max_episode_steps
-	cfg.env_cfg.env_horizon = cfg.eval_env_cfg.env_horizon = env.max_episode_steps
 	env = ManiSkillVectorEnv(env, ignore_terminations=True)
+	cfg.env_cfg.env_horizon = cfg.eval_env_cfg.env_horizon = env.max_episode_steps = gym_utils.find_max_episode_steps_value(env)
 	return env

--- a/examples/baselines/tdmpc2/envs/wrappers/pixels.py
+++ b/examples/baselines/tdmpc2/envs/wrappers/pixels.py
@@ -10,18 +10,18 @@ class PixelWrapper(gym.Wrapper):
 	Wrapper for pixel observations. Works with Maniskill vectorized environments
 	"""
 
-	def __init__(self, cfg, env, num_frames=3):
+	def __init__(self, cfg, env, num_envs, num_frames=3):
 		super().__init__(env)
 		self.cfg = cfg
 		self.env = env
 		self.observation_space = gym.spaces.Box(
-			low=0, high=255, shape=(cfg.num_envs, num_frames*3, cfg.render_size, cfg.render_size), dtype=np.uint8
+			low=0, high=255, shape=(num_envs, num_frames*3, cfg.render_size, cfg.render_size), dtype=np.uint8
 		)
 		self._frames = deque([], maxlen=num_frames)
 		self._render_size = cfg.render_size
 
 		# # Using tensor to mimick self._frames = deque([], maxlen=num_frames) so the data remain on the same device **turned out to be slower**
-		# self._frames = torch.zeros((cfg.num_envs, num_frames*3, cfg.render_size, cfg.render_size)).to(self.env.device)
+		# self._frames = torch.zeros((num_envs, num_frames*3, cfg.render_size, cfg.render_size)).to(self.env.device)
 		# self._frames_idx = 0
 		# self._frames_maxlen = num_frames
 		# self._render_size = cfg.render_size

--- a/examples/baselines/tdmpc2/evaluate.py
+++ b/examples/baselines/tdmpc2/evaluate.py
@@ -50,7 +50,7 @@ def evaluate(cfg: dict):
 	print(colored(f'Checkpoint: {cfg.checkpoint}', 'blue', attrs=['bold']))
 
 	# Make environment
-	env = make_envs(cfg)
+	env = make_envs(cfg, cfg.num_envs)
 
 	# Load agent
 	agent = TDMPC2(cfg)

--- a/examples/baselines/tdmpc2/train.py
+++ b/examples/baselines/tdmpc2/train.py
@@ -52,7 +52,8 @@ def train(cfg: dict):
 	trainer_cls = OnlineTrainer # OfflineTrainer if cfg.multitask else OnlineTrainer
 	trainer = trainer_cls(
 		cfg=cfg,
-		env=make_envs(cfg),
+		env=make_envs(cfg, cfg.num_envs),
+		eval_env=make_envs(cfg, cfg.num_eval_envs),
 		agent=TDMPC2(cfg),
 		buffer=Buffer(cfg),
 		logger=Logger(cfg),

--- a/examples/baselines/tdmpc2/trainer/base.py
+++ b/examples/baselines/tdmpc2/trainer/base.py
@@ -1,15 +1,17 @@
 from tdmpc2 import TDMPC2
 from common.buffer import Buffer
+from common.logger import Logger
 
 class Trainer:
 	"""Base trainer class for TD-MPC2."""
 
-	def __init__(self, cfg, env, agent, buffer, logger):
+	def __init__(self, cfg, env, eval_env, agent, buffer, logger):
 		self.cfg = cfg
 		self.env = env
+		self.eval_env = eval_env
 		self.agent: TDMPC2 = agent
 		self.buffer: Buffer = buffer
-		self.logger = logger
+		self.logger: Logger = logger
 		print('Architecture:', self.agent.model)
 		print("Learnable parameters: {:,}".format(self.agent.model.total_params))
 


### PR DESCRIPTION
#439 
- Separated `eval_env` from train `env` (#486)
  - `eval_env` is now used for evaluation. The only difference between `env` and `eval_env` is num_envs. 
  - `num_eval_envs` in configs now defines the num_envs of `eval_env`.
- Fixed `max_episode_steps` (#528)
  - Newer gymnasium and ManiskillVectorEnv doesn't contrain default `max_episode_steps` as an attribute. Therefore, default `max_episode_steps` is now determined by `gym_utils.find_max_episode_steps_value(env)`.
- Fixed wandb logging to log exactly `eval_episodes` 
  - Realized that wandb logging in evaluation wasn't logging exactly `eval_episodes` (it was a multiple of `num_eval_envs`). Futhermore, only `num_eval_envs` videos were logged at each evaluation.
  - It is now fixed to log exactly `eval_episodes` at each evaluation.