### PR TITLE
panda wristcam initialization added

### DIFF
--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -166,6 +166,36 @@ class TableSceneBuilder(SceneBuilder):
             agent.agents[0].robot.set_pose(
                 sapien.Pose([0, -0.75, 0], q=euler2quat(0, 0, np.pi / 2))
             )
+        elif self.env.robot_uids == ("panda_wristcam", "panda_wristcam"):
+            agent: MultiAgent = self.env.agent
+            qpos = np.array(
+                [
+                    0.0,
+                    np.pi / 8,
+                    0,
+                    -np.pi * 5 / 8,
+                    0,
+                    np.pi * 3 / 4,
+                    np.pi / 4,
+                    0.04,
+                    0.04,
+                ]
+            )
+            qpos = (
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                )
+                + qpos
+            )
+            qpos[:, -2:] = 0.04
+            agent.agents[1].reset(qpos)
+            agent.agents[1].robot.set_pose(
+                sapien.Pose([0, 0.75, 0], q=euler2quat(0, 0, -np.pi / 2))
+            )
+            agent.agents[0].reset(qpos)
+            agent.agents[0].robot.set_pose(
+                sapien.Pose([0, -0.75, 0], q=euler2quat(0, 0, np.pi / 2))
+            )
         elif (
             "dclaw" in self.env.robot_uids
             or "allegro" in self.env.robot_uids


### PR DESCRIPTION
### Quick fix for missing initialization
Found invalid initialization for pair `panda wristcam` robots in `TwoRobotPickCube` environment. Added proper initialization in `TableSceneBuilder` similar to `panda`.