### PR TITLE
[Feature]: Add CPU multiprocessing for Panda Motionplanner's Trajecto…

### DIFF
--- a/mani_skill/examples/motionplanning/panda/run.py
+++ b/mani_skill/examples/motionplanning/panda/run.py
@@ -8,7 +8,7 @@ import numpy as np
 from tqdm import tqdm
 import os.path as osp
 from mani_skill.utils.wrappers.record import RecordEpisode
-from mani_skill.trajectory.merge_trajectory import merge_h5
+from mani_skill.trajectory.merge_trajectory import merge_trajectories
 from mani_skill.examples.motionplanning.panda.solutions import solvePushCube, solvePickCube, solveStackCube, solvePegInsertionSide, solvePlugCharger
 MP_SOLUTIONS = {
     "PickCube-v1": solvePickCube,
@@ -122,7 +122,7 @@ def main(args):
         pool.close()
         # Merge trajectory files
         output_path = res[0][: -len("0.h5")] + "h5"
-        merge_h5(output_path, res)
+        merge_trajectories(output_path, res)
         for h5_path in res:
             tqdm.write(f"Remove {h5_path}")
             os.remove(h5_path)

--- a/mani_skill/examples/motionplanning/panda/run.py
+++ b/mani_skill/examples/motionplanning/panda/run.py
@@ -113,7 +113,9 @@ def _main(args, proc_id: int = 0, start_seed: int = 0) -> str:
     return output_h5_path
 
 def main(args):
-    if args.num_procs > 1:
+    if args.num_procs > 1 and args.num_procs < args.num_traj:
+        if args.num_traj < args.num_procs:
+            raise ValueError("Number of trajectories should be greater than or equal to number of processes")
         args.num_traj = args.num_traj // args.num_procs
         seeds = [*range(0, args.num_procs * args.num_traj, args.num_traj)]
         pool = mp.Pool(args.num_procs)

--- a/mani_skill/examples/motionplanning/panda/run.py
+++ b/mani_skill/examples/motionplanning/panda/run.py
@@ -1,9 +1,14 @@
+import multiprocessing as mp
+import os
+from copy import deepcopy
+import time
 import argparse
 import gymnasium as gym
 import numpy as np
 from tqdm import tqdm
 import os.path as osp
 from mani_skill.utils.wrappers.record import RecordEpisode
+from mani_skill.trajectory.merge_trajectory import merge_h5
 from mani_skill.examples.motionplanning.panda.solutions import solvePushCube, solvePickCube, solveStackCube, solvePegInsertionSide, solvePlugCharger
 MP_SOLUTIONS = {
     "PickCube-v1": solvePickCube,
@@ -26,9 +31,10 @@ def parse_args(args=None):
     parser.add_argument("--traj-name", type=str, help="The name of the trajectory .h5 file that will be created.")
     parser.add_argument("--shader", default="default", type=str, help="Change shader used for rendering. Default is 'default' which is very fast. Can also be 'rt' for ray tracing and generating photo-realistic renders. Can also be 'rt-fast' for a faster but lower quality ray-traced renderer")
     parser.add_argument("--record-dir", type=str, default="demos", help="where to save the recorded trajectories")
+    parser.add_argument("--num-procs", type=int, default=1, help="Number of processes to use to help parallelize the trajectory replay process. This uses CPU multiprocessing and only works with the CPU simulation backend at the moment.")
     return parser.parse_args()
 
-def main(args):
+def _main(args, proc_id: int = 0) -> str:
     env_id = args.env_id
     env = gym.make(
         env_id,
@@ -43,18 +49,27 @@ def main(args):
     )
     if env_id not in MP_SOLUTIONS:
         raise RuntimeError(f"No already written motion planning solutions for {env_id}. Available options are {list(MP_SOLUTIONS.keys())}")
+    
+    if not args.traj_name:
+        new_traj_name = time.strftime("%Y%m%d_%H%M%S")
+    else:
+        new_traj_name = args.traj_name
+
+    if args.num_procs > 1:
+        new_traj_name = new_traj_name + "." + str(proc_id)
     env = RecordEpisode(
         env,
         output_dir=osp.join(args.record_dir, env_id, "motionplanning"),
-        trajectory_name=args.traj_name, save_video=args.save_video,
+        trajectory_name=new_traj_name, save_video=args.save_video,
         source_type="motionplanning",
         source_desc="official motion planning solution from ManiSkill contributors",
         video_fps=30,
         save_on_reset=False
     )
+    output_h5_path = env._h5_file.filename
     solve = MP_SOLUTIONS[env_id]
     print(f"Motion Planning Running on {env_id}")
-    pbar = tqdm(range(args.num_traj))
+    pbar = tqdm(range(args.num_traj), desc=f"proc_id: {proc_id}")
     seed = 0
     successes = []
     solution_episode_lengths = []
@@ -95,6 +110,28 @@ def main(args):
             if passed == args.num_traj:
                 break
     env.close()
+    return output_h5_path
+
+def main(args):
+    start = time.time()
+    if args.num_procs > 1:
+        args.num_traj = args.num_traj // args.num_procs
+        pool = mp.Pool(args.num_procs)
+        proc_args = [(deepcopy(args), i) for i in range(args.num_procs)]
+        res = pool.starmap(_main, proc_args)
+        pool.close()
+        # Merge trajectory files
+        output_path = res[0][: -len("0.h5")] + "h5"
+        merge_h5(output_path, res)
+        for h5_path in res:
+            tqdm.write(f"Remove {h5_path}")
+            os.remove(h5_path)
+            json_path = h5_path.replace(".h5", ".json")
+            tqdm.write(f"Remove {json_path}")
+            os.remove(json_path)
+    else:
+        _main(args)
 
 if __name__ == "__main__":
+    mp.set_start_method("spawn")
     main(parse_args())

--- a/mani_skill/trajectory/merge_trajectory.py
+++ b/mani_skill/trajectory/merge_trajectory.py
@@ -1,60 +1,76 @@
 import argparse
 from pathlib import Path
-
 import h5py
+from mani_skill.utils.logging_utils import logger
 
 from mani_skill.utils.io_utils import dump_json, load_json
 
 
-def merge_h5(output_path: str, traj_paths, recompute_id=True):
-    print("Merge to", output_path)
+def merge_trajectories(output_path: str, traj_paths: list, recompute_id: bool = True):
+    """
+    Merges multiple JSON and H5 files into a single JSON and H5 file.
+
+    This function combines the contents of multiple JSON and H5 files. It keeps the first value for all keys
+    (other than "episodes") and logs a warning for any differences. The "episodes" from each JSON file are merged
+    into a single list, and the corresponding H5 data is copied to the output H5 file.
+
+    Args:
+        output_path (str): The path to the output H5 file. The corresponding JSON file will be saved with the same
+                           name but with a .json extension.
+        traj_paths (list): A list of paths to the input trajectory files (H5 files). The corresponding JSON files
+                           should have the same name but with a .json extension.
+        recompute_id (bool): If True, recompute the episode IDs to ensure they are unique. If False, keep the original
+                             episode IDs.
+
+    Raises:
+        AssertionError: If there is a conflict in the episode IDs when recompute_id is False.
+    """
+    logger.info(f"Merging {output_path}")
 
     merged_h5_file = h5py.File(output_path, "w")
     merged_json_path = output_path.replace(".h5", ".json")
-    merged_json_data = {"env_info": {}, "episodes": []}
-    _env_info = None
+    merged_json_data = {"episodes": []}
     cnt = 0
 
     for traj_path in traj_paths:
         traj_path = str(traj_path)
-        print("Merging", traj_path)
+        logger.info(f"Merging{traj_path}")
 
-        h5_file = h5py.File(traj_path, "r")
-        json_path = traj_path.replace(".h5", ".json")
-        json_data = load_json(json_path)
+        with h5py.File(traj_path, "r") as h5_file:
+            json_data = load_json(traj_path.replace(".h5", ".json"))
+            
+            # For keys other than episodes, keep the first data
+            # and check if there is any conflict with other data.
+            for key, value in json_data.items():
+                if key == "episodes":
+                    continue
+                if key not in merged_json_data:
+                    merged_json_data[key] = value
+                else:
+                    if merged_json_data[key] != value:
+                        logger.warning(f"Conflict detected for key {key} in {traj_path}: {merged_json_data[key]} != {value}")
 
-        # Check env info
-        env_info = json_data["env_info"]
-        if _env_info is None:
-            _env_info = env_info
-            merged_json_data["env_info"] = _env_info
-        else:
-            assert str(env_info) == str(_env_info), traj_path
+            # Merge episodes
+            for ep in json_data["episodes"]:
+                episode_id = ep["episode_id"]
+                traj_id = f"traj_{episode_id}"
 
-        # Merge
-        for ep in json_data["episodes"]:
-            episode_id = ep["episode_id"]
-            traj_id = f"traj_{episode_id}"
+                # Copy h5 data
+                if recompute_id:
+                    new_traj_id = f"traj_{cnt}"
+                else:
+                    new_traj_id = traj_id
 
-            # Copy h5 data
-            if recompute_id:
-                new_traj_id = f"traj_{cnt}"
-            else:
-                new_traj_id = traj_id
+                assert new_traj_id not in merged_h5_file, new_traj_id
+                h5_file.copy(traj_id, merged_h5_file, new_traj_id)
 
-            assert new_traj_id not in merged_h5_file, new_traj_id
-            h5_file.copy(traj_id, merged_h5_file, new_traj_id)
+                # Copy json data
+                if recompute_id:
+                    ep["episode_id"] = cnt
+                merged_json_data["episodes"].append(ep)
 
-            # Copy json data
-            if recompute_id:
-                ep["episode_id"] = cnt
-            merged_json_data["episodes"].append(ep)
+                cnt += 1
 
-            cnt += 1
-
-        h5_file.close()
-
-    # Ignore commit info
     merged_h5_file.close()
     dump_json(merged_json_path, merged_json_data, indent=2)
 
@@ -74,7 +90,7 @@ def main():
     output_dir = Path(args.output_path).parent
     output_dir.mkdir(exist_ok=True, parents=True)
 
-    merge_h5(args.output_path, traj_paths)
+    merge_trajectories(args.output_path, traj_paths)
 
 
 if __name__ == "__main__":

--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -18,7 +18,7 @@ from tqdm.auto import tqdm
 
 import mani_skill.envs
 from mani_skill.trajectory import utils as trajectory_utils
-from mani_skill.trajectory.merge_trajectory import merge_h5
+from mani_skill.trajectory.merge_trajectory import merge_trajectories
 from mani_skill.trajectory.utils.actions import conversion as action_conversion
 from mani_skill.utils import common, io_utils, wrappers
 
@@ -320,7 +320,7 @@ def main(args):
         if args.save_traj:
             # A hack to find the path
             output_path = res[0][: -len("0.h5")] + "h5"
-            merge_h5(output_path, res)
+            merge_trajectories(output_path, res)
             for h5_path in res:
                 tqdm.write(f"Remove {h5_path}")
                 os.remove(h5_path)


### PR DESCRIPTION
Uses an elementary method that lets each process in `num_procs` to generate `num_traj // num_procs` trajectory.

Discussion on next steps:
- I see that in motionplanner's solution folder, there are several `solve` methods defined for different tasks. For example, `solve` in [`pick_cube.py`](https://github.com/haosulab/ManiSkill/blob/7b84f94dfc07c3cfbb6df4b1c12d3515d4253278/mani_skill/examples/motionplanning/panda/solutions/pick_cube.py). And it seems to be using the `PandaArmMotionPlanningSolver` environment when solving. From my understanding, it might help if `solve` method is being moved to `PandaArmMotionPlanningSolver` and `PandaArmMotionPlanningSolver` is wrapped as a vectorized environment for multiprocessing. Would be greatly appreciated to know if this rationale sounds correct, thank you.
