### PR TITLE
[BugFix] ControllerDict prevented before_simulation_step on child controllers

### DIFF
--- a/mani_skill/agents/controllers/base_controller.py
+++ b/mani_skill/agents/controllers/base_controller.py
@@ -208,6 +208,10 @@ class DictController(BaseController):
                 self.single_action_space, n=self.scene.num_envs
             )
 
+    def before_simulation_step(self):
+        for controller in self.controllers.values():
+            controller.before_simulation_step()
+
     def _initialize_action_space(self):
         # Explicitly create a list of key-value tuples
         # Otherwise, spaces.Dict will sort keys if a dict is provided


### PR DESCRIPTION
In the [BaseAgent class](https://github.com/haosulab/ManiSkill/blob/main/mani_skill/agents/base_agent.py), before_simulation_step calls it's controller object's before_simulation_step. When that controller is of type [DictController or its subclass CombinedController](https://github.com/haosulab/ManiSkill/blob/main/mani_skill/agents/controllers/base_controller.py#L183) the controller inherits baseController's before_simulation_step, which is an empty function. When the agent calls a DictController's before_simulation_step it always calls the empty function. If anyone writes a custom controller requiring before_simulation_step and their robot requires a DictController or it's children, then they will be unable to call the custom controller's before_simulation_step. In this pull I added a function to DictController to fix this issue.