### PR TITLE
[Docs] Fix Typos in docs

### DIFF
--- a/docs/source/user_guide/additional_resources/performance_benchmarking.md
+++ b/docs/source/user_guide/additional_resources/performance_benchmarking.md
@@ -1,10 +1,10 @@
 # Performance Benchmarking
 
-This page documents code and results of benchmarking various robotics simulators on a number of dimensions. It is still a WIP as we write more fair benchmarking environments for other simulators. Given the number of factors that impact simulation speed and rendering (e.g number of objects, geometry complexity etc.) trends that appear in results in this page may not necesarily be the case on some environments.
+This page documents code and results of benchmarking various robotics simulators on a number of dimensions. It is still a WIP as we write more fair benchmarking environments for other simulators. Given the number of factors that impact simulation speed and rendering (e.g number of objects, geometry complexity etc.) trends that appear in results in this page may not necessarily be the case on some environments.
 
 Currently we just compare ManiSkill and [Isaac Lab](https://github.com/isaac-sim/IsaacLab) on one task, Cartpole Balancing (control). For details on benchmarking methodology see [this section](#benchmarking-detailsmethodology)
 
-Raw benchmark results can be read from the .csv files in the [results folder on GitHub](https://github.com/haosulab/ManiSkill/blob/main/docs/source/user_guide/additional_resources/benchmarking_results). There are also plotted figures in that folder. Below we show a selection of some of the figures/results from testing on a RTX 4090. The figures are also sometimes annotated with the GPU memory usage in GB. 
+Raw benchmark results can be read from the .csv files in the [results folder on GitHub](https://github.com/haosulab/ManiSkill/blob/main/docs/source/user_guide/additional_resources/benchmarking_results). There are also plotted figures in that folder. Below we show a selection of some of the figures/results from testing on an RTX 4090. The figures are also sometimes annotated with the GPU memory usage in GB. 
 
 Overall, ManiSkill is faster than Isaac Lab on the majority of settings and is much more GPU memory efficient, especially for realistic camera setups. GPU memory efficiency is particularly important for machine learning methods like RL which rely on large replay buffers on the GPU. However we note that this is not a pure apples-to-apples comparison due to differences in rendering techniques and so we show a qualitative comparison of the same task in Isaac Lab and ManiSkill. See the note below for more details.
 

--- a/docs/source/user_guide/concepts/controllers.md
+++ b/docs/source/user_guide/concepts/controllers.md
@@ -122,7 +122,7 @@ The same as PD EE Pose controller but there is no rotation control and actions a
 
 ## Deep Dive Example of the Franka Emika Panda Robot Controllers:
 
-To help detail how controllers work in detail, below we explain with formulae how the controllers are controlling the root in simulation.
+To help detail how controllers work in detail, below we explain with formulae how the controllers are controlling the robot in simulation.
 
 ### Terminology
 

--- a/docs/source/user_guide/concepts/observation.md
+++ b/docs/source/user_guide/concepts/observation.md
@@ -8,7 +8,7 @@ In general, the observation is organized as a dictionary (with an observation sp
 
 There are two raw observations modes: `state_dict` (privileged states) and `sensor_data` (raw sensor data like visual data without postprocessing). `state` is a flat version of `state_dict`. `rgb+depth`, `rgb+depth+segmentation` (or any combination of `rgb`, `depth`, `segmentation`), and `pointcloud` apply post-processing on `sensor_data` to give convenient representations of visual data.
 
-The details here show the unbatched shapes. In general there is always a batch dimension unless you are using CPU simulation. Moreover, we annotate what dtype some values are, where some have both a torch and numpy dtype depending on whether you are using GPU or CPU simulation repspectively.
+The details here show the unbatched shapes. In general there is always a batch dimension unless you are using CPU simulation. Moreover, we annotate what dtype some values are, where some have both a torch and numpy dtype depending on whether you are using GPU or CPU simulation respectively.
 
 ### state_dict
 

--- a/docs/source/user_guide/datasets/demos.md
+++ b/docs/source/user_guide/datasets/demos.md
@@ -94,7 +94,7 @@ env_state_i = trajectory_utils.index_dict(env_states, i)
 # now env_state_i is the same as the data env.get_state_dict() returned at timestep i
 ```
 
-These tools are also used in the PyTorch Dataset implementation we provide which is explained the nect section
+These tools are also used in the PyTorch Dataset implementation we provide which is explained in the next section
 
 ## Loading Trajectory Datasets
 

--- a/docs/source/user_guide/getting_started/docker.md
+++ b/docs/source/user_guide/getting_started/docker.md
@@ -23,7 +23,7 @@ docker run --rm -it --gpus all maniskill/base python -m mani_skill.examples.demo
 docker run --rm -it --gpus all maniskill/base python -m mani_skill.examples.benchmarking.gpu_sim
 ```
 
-Note that inside a docker image you generally cannot render a GUI to see the results. You can still record videos and the demo scripts have options to record videos insteading of rendering a GUI.
+Note that inside a docker image you generally cannot render a GUI to see the results. You can still record videos and the demo scripts have options to record videos instead of rendering a GUI.
 
 <!-- 
 ## Run GUI Applications

--- a/docs/source/user_guide/getting_started/installation.md
+++ b/docs/source/user_guide/getting_started/installation.md
@@ -46,7 +46,7 @@ Once you are done here, you can head over to the [quickstart page](./quickstart.
 The following section is to install [NVIDIA Warp](https://github.com/NVIDIA/warp) for soft-body tasks. You can skip it if you do not need soft-body tasks yet.
 :::
 
-The soft-body tasks in ManiSkill are supported by SAPIEN and customized NVIDIA Warp. **CUDA toolkit >= 11.3 and gcc** are required. You can download and install the CUDA toolkit from the [offical website](https://developer.nvidia.com/cuda-downloads?target_os=Linux).
+The soft-body tasks in ManiSkill are supported by SAPIEN and customized NVIDIA Warp. **CUDA toolkit >= 11.3 and gcc** are required. You can download and install the CUDA toolkit from the [official website](https://developer.nvidia.com/cuda-downloads?target_os=Linux).
 
 Assuming the CUDA toolkit is installed at `/usr/local/cuda`, you need to ensure `CUDA_PATH` or `CUDA_HOME` is set properly:
 
@@ -201,7 +201,7 @@ If you still have some issues, you can check the NVIDIA drivers. First run
 ldconfig -p | grep libGLX_nvidia
 ```
 
-If `libGLX_nvidia.so` is not found, they it is likely that you have installed an incorrect driver. To get the right driver on linux, it is recommended to install `nvidia-driver-xxx` (do not use the ones with server in the package name) and to avoid using any other method of installation like a runfile
+If `libGLX_nvidia.so` is not found, then it is likely that you have installed an incorrect driver. To get the right driver on linux, it is recommended to install `nvidia-driver-xxx` (do not use the ones with server in the package name) and to avoid using any other method of installation like a runfile
 
 ### Uninstallation
 

--- a/docs/source/user_guide/reinforcement_learning/setup.md
+++ b/docs/source/user_guide/reinforcement_learning/setup.md
@@ -6,7 +6,7 @@ This page documents key things to know when setting up ManiSkill environments fo
 - How to [**correctly** evaluate RL policies fairly](#evaluation)
 - [Useful Wrappers](#useful-wrappers)
 
-ManiSkill environments are created by gymnasium's `make` function. The result is by default a "batched" environment where every input and output is batched. Note that this is not standard gymnasium API. If you want the standard gymnasium environemnt / vectorized environment API see the next sections.
+ManiSkill environments are created by gymnasium's `make` function. The result is by default a "batched" environment where every input and output is batched. Note that this is not standard gymnasium API. If you want the standard gymnasium environment / vectorized environment API see the next sections.
 
 ```python
 import mani_skill.envs
@@ -145,4 +145,4 @@ RL practitioners often use wrappers to modify and augment environments. These ar
 
 In old environments/benchmarks, people often have used `env.render(mode="rgb_array")` or `env.render()` to get image inputs for RL agents. This is not correct because image observations are returned by `env.reset()` and `env.step()` directly and `env.render` is just for visualization/video recording only in ManiSkill.
 
-For robotics tasks observations often are composed of state information (like robot joint angles) and image observations (like camera images). All tasks in ManiSkill will specifically remove certain priviliged state information from the observations when the `obs_mode` is not `state` or `state_dict` like ground truth object poses. Moreover, the image observations returned by `env.reset()` and `env.step()` are usually from cameras that are positioned in specific locations to provide a good view of the task to make it solvable.
+For robotics tasks observations often are composed of state information (like robot joint angles) and image observations (like camera images). All tasks in ManiSkill will specifically remove certain privileged state information from the observations when the `obs_mode` is not `state` or `state_dict` like ground truth object poses. Moreover, the image observations returned by `env.reset()` and `env.step()` are usually from cameras that are positioned in specific locations to provide a good view of the task to make it solvable.


### PR DESCRIPTION
necesarily - > necessarily
root - > robot
repspectively -> respectively
offical -> official
environemnt - > environment