### PR TITLE
[Docs] Fix Typos and Minor Grammar Issues in `index.md` file

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,25 +9,25 @@
 [![Docs status](https://img.shields.io/badge/docs-passing-brightgreen.svg)](https://maniskill.readthedocs.io/en/latest/)
 [![Discord](https://img.shields.io/discord/996566046414753822?logo=discord)](https://discord.gg/x8yUZe5AdN)
 
-ManiSkill is a powerful unified framework for robot simulation and training powered by [SAPIEN](https://sapien.ucsd.edu/), with a strong focus on manipulation skills. The entire tech stack is as open-source as possible and ManiSkill v3 is in beta release now. Among its features include:
-- GPU parallelized visual data collection system. On the high end you can collect RGBD + Segmentation data at 30,000+ FPS with a 4090 GPU, 10-1000x faster compared to most other simulators.
-- GPU parallelized simulation, enabling high throughput state-based synthetic data collection in simulation
-- GPU parallelized heteogeneous simuluation, where every parallel environment has a completely different scene/set of objects
-- Example tasks cover a wide range of different robot embodiments (humanoids, mobile manipulators, single-arm robots) as well as a wide range of different tasks (table-top, drawing/cleaning, dextrous manipulation)
-- Flexible and simple task building API that abstracts away much of the complex GPU memory management code via an object oriented design
-- Real2sim environments for scalably evaluating real-world policies 60-100x faster via GPU simulation.
+ManiSkill is a powerful unified framework for robot simulation and training powered by [SAPIEN](https://sapien.ucsd.edu/), with a strong focus on manipulation skills. The entire tech stack is as open-source as possible, and ManiSkill v3 is in beta release now. Among its features are:
+- GPU-parallelized visual data collection system. On the high end, you can collect RGBD + Segmentation data at 30,000+ FPS with a 4090 GPU, which is 10-1000x faster compared to most other simulators.
+- GPU-parallelized simulation, enabling high-throughput state-based synthetic data collection in simulation.
+- GPU-parallelized heterogeneous simulation, where every parallel environment has a completely different scene/set of objects.
+- Example tasks cover a wide range of different robot embodiments (humanoids, mobile manipulators, single-arm robots) as well as a wide range of different tasks (table-top, drawing/cleaning, dexterous manipulation).
+- Flexible and simple task-building API that abstracts away much of the complex GPU memory management code via an object-oriented design.
+- Real-to-sim environments for scalably evaluating real-world policies 60-100x faster via GPU simulation.
 
 <!-- TODO replace paper link with arxiv link when it is out -->
-For more details we encourage you to take a look at our [paper](https://arxiv.org/abs/2410.00425).
+For more details, we encourage you to take a look at our [paper](https://arxiv.org/abs/2410.00425).
 
-There are more features to be added to ManiSkill 3, see [our roadmap](https://maniskill.readthedocs.io/en/latest/roadmap/index.html) for planned features that will be added over time before the official v3 is released.
+There are more features to be added to ManiSkill 3. See [our roadmap](https://maniskill.readthedocs.io/en/latest/roadmap/index.html) for planned features that will be added over time before the official v3 release.
 
-Please refer to our [documentation](https://maniskill.readthedocs.io/en/latest/user_guide) to learn more information from tutorials on building tasks to data collection.
+Please refer to our [documentation](https://maniskill.readthedocs.io/en/latest/user_guide) to learn more from tutorials on building tasks to data collection.
 
 **NOTE:**
-This project currently is in a **beta release**, so not all features have been added in yet and there may be some bugs. If you find any bugs or have any feature requests please post them to our [GitHub issues](https://github.com/haosulab/ManiSkill/issues/) or discuss about them on [GitHub discussions](https://github.com/haosulab/ManiSkill/discussions/). We also have a [Discord Server](https://discord.gg/x8yUZe5AdN) through which we make announcements and discuss about ManiSkill.
+This project currently is in a **beta release**, so not all features have been added yet, and there may be some bugs. If you find any bugs or have any feature requests, please post them to our [GitHub issues](https://github.com/haosulab/ManiSkill/issues/) or discuss them on [GitHub discussions](https://github.com/haosulab/ManiSkill/discussions/). We also have a [Discord Server](https://discord.gg/x8yUZe5AdN) through which we make announcements and discuss ManiSkill.
 
-Users looking for the original ManiSkill2 can find the commit for that codebase at the [v0.5.3 tag](https://github.com/haosulab/ManiSkill/tree/v0.5.3)
+Users looking for the original ManiSkill2 can find the commit for that codebase at the [v0.5.3 tag](https://github.com/haosulab/ManiSkill/tree/v0.5.3).
 
 ```{toctree}
 :maxdepth: 1


### PR DESCRIPTION
- Corrected typos: "heteogeneous" to "heterogeneous," "simuluation" to "simulation."
- Added hyphenation for terms like "GPU-parallelized" and "Real-to-sim" for consistency.
- Made minor grammar and phrasing improvements for better readability.
- Updated documentation in the `test` folder accordingly.