### PR TITLE
[BugFix] Add error handling for Panda's Motionplanner

### DIFF
--- a/mani_skill/examples/motionplanning/panda/run.py
+++ b/mani_skill/examples/motionplanning/panda/run.py
@@ -76,7 +76,12 @@ def _main(args, proc_id: int = 0, start_seed: int = 0) -> str:
     failed_motion_plans = 0
     passed = 0
     while True:
-        res = solve(env, seed=seed, debug=False, vis=True if args.vis else False)
+        try:
+            res = solve(env, seed=seed, debug=False, vis=True if args.vis else False)
+        except Exception as e:
+            print(f"Cannot find valid solution because of an error in motion planning solution: {e}")
+            res = -1
+
         if res == -1:
             success = False
             failed_motion_plans += 1


### PR DESCRIPTION
Handle errors thrown by `mplib`'s solver by treating the trial as a failed planning attempt instead of stopping the run.