### PR TITLE
[BugFix] Fix OpenCabinetDrawer-v1

### DIFF
--- a/docs/source/user_guide/tutorials/custom_tasks/intro.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/intro.md
@@ -96,6 +96,9 @@ class PushCubeEnv(BaseEnv):
                 base_color=[1, 0, 0, 1],
             ),
         )
+        # set an initial pose for the cube so that it initially spawns
+        # where nothing else can collide with it. We will randomize this later
+        builder.initial_pose = sapien.Pose(p=[1, 1, 1], q=[1, 0, 0, 0])
         self.obj = builder.build(name="cube")
         # PushCube has some other code after this removed for brevity that 
         # spawns a goal object (a red/white target) stored at self.goal_region
@@ -107,8 +110,11 @@ You can build a **kinematic** actor with `builder.build_kinematic` and a **stati
 - Kinematic actors can have their pose changed at any time. Static actors must have an initial pose set before calling `build_static` via `builder.initial_pose = ...`
 - Use static instead of kinematic whenever possible as it saves a lot of GPU memory. Static objects must have an initial pose set before building via `builder.initial_pose = ...`.
 
+You may notice that an initial pose is arbitrarily set for the cube. We **strongly recommend** you set initial poses of any objects created such that they do not collide if they were placed at those poses. This helps ensure the GPU simulation is stable on the first step of the environment and can be necessary to do even if you are setting object poses during episode initialization.
+
+
 We also provide some functions that build some more complex shapes that you can use by importing the following:
-```
+```python
 from mani_skill.utils.building import actors
 ```
 

--- a/docs/source/user_guide/tutorials/custom_tasks/intro.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/intro.md
@@ -105,7 +105,7 @@ You can build a **kinematic** actor with `builder.build_kinematic` and a **stati
 - Dynamic actors can be moved around by forces/other objects (e.g. a robot) and are fully physically simulated
 - Kinematic and static actors are fixed in place but can block objects from moving through them (e.g. a wall, a kitchen counter).
 - Kinematic actors can have their pose changed at any time. Static actors must have an initial pose set before calling `build_static` via `builder.initial_pose = ...`
-- Use static instead of kinematic whenever possible as it saves a lot of GPU memory
+- Use static instead of kinematic whenever possible as it saves a lot of GPU memory. Static objects must have an initial pose set before building via `builder.initial_pose = ...`.
 
 We also provide some functions that build some more complex shapes that you can use by importing the following:
 ```
@@ -139,7 +139,9 @@ We recommend you to first complete this tutorial before moving onto the next.
 
 ## Episode Initialization / Randomization
 
-Task initialization and randomization is handled in the `_initialize_episode` function and is called whenever `env.reset` is called. The objective here is to set the initial states of objects, including the robot. As the task ideally should be simulatable on the GPU, batched code is unavoidable. Note that furthermore, by default everything in ManiSkill tries to stay batched, even if there is only one element. Finally, like `_load_scene` the options argument is also passed down here if needed.
+Task initialization and randomization is handled in the `_initialize_episode` function and is called whenever `env.reset` is called. The objective here is to set the initial states of all non-static objects, including the robot. Note that objects that do not have initial poses set when building or set during episode initialization won't necessarily spawn at the origin.
+
+As the task ideally should be simulatable on the GPU, batched code is unavoidable. Note that furthermore, by default everything in ManiSkill tries to stay batched, even if there is only one element. Finally, like `_load_scene` the options argument is also passed down here if needed.
 
 An example from part of the PushCube task
 

--- a/docs/source/user_guide/tutorials/custom_tasks/intro.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/intro.md
@@ -138,7 +138,7 @@ class PushCubeEnv(BaseEnv):
 ```
 The TableSceneBuilder is perfect for easily building table-top tasks, it creates a table and floor for you, and places the fetch and panda robots in reasonable locations.
 
-A tutorial on how to build actors beyond primitive shapes (boxes, spheres etc.) and load articulated objects is covered in the [tutorial after this one](./loading_objects.md). More advanced features like heterogeneous simulation with different objects/articulations in different parallel environments is covered in the [advanced features page](./advanced.md). Finally if you intend on randomizing objects/textures etc. in parallel environments, we highly recommend understanding the [batched RNG system](../../concepts/rng.md) which details how to ensure reproducibility in your environments.
+A tutorial on how to build actors beyond primitive shapes (boxes, spheres etc.) and load articulated objects is covered in the [tutorial after this one](./loading_objects.md). More advanced features like heterogeneous simulation with different objects/articulations in different parallel environments is covered in the [advanced features page](./advanced.md). Finally, if you intend on randomizing objects/textures etc. in parallel environments, we highly recommend understanding the [batched RNG system](../../concepts/rng.md) which details how to ensure reproducibility in your environments.
 
 We recommend you to first complete this tutorial before moving onto the next.
 

--- a/examples/baselines/ppo/ppo.py
+++ b/examples/baselines/ppo/ppo.py
@@ -35,7 +35,7 @@ class Args:
     """if toggled, this experiment will be tracked with Weights and Biases"""
     wandb_project_name: str = "ManiSkill"
     """the wandb's project name"""
-    wandb_entity: str = None
+    wandb_entity: Optional[str] = None
     """the entity (team) of wandb's project"""
     capture_video: bool = True
     """whether to capture videos of the agent performances (check out `videos` folder)"""
@@ -43,7 +43,7 @@ class Args:
     """whether to save model into the `runs/{run_name}` folder"""
     evaluate: bool = False
     """if toggled, only runs evaluation with the given model checkpoint and saves the evaluation trajectories"""
-    checkpoint: str = None
+    checkpoint: Optional[str] = None
     """path to a pretrained checkpoint file to start evaluation/training from"""
 
     # Algorithm specific arguments

--- a/examples/baselines/ppo/ppo_rgb.py
+++ b/examples/baselines/ppo/ppo_rgb.py
@@ -36,7 +36,7 @@ class Args:
     """if toggled, this experiment will be tracked with Weights and Biases"""
     wandb_project_name: str = "ManiSkill"
     """the wandb's project name"""
-    wandb_entity: str = None
+    wandb_entity: Optional[str] = None
     """the entity (team) of wandb's project"""
     capture_video: bool = True
     """whether to capture videos of the agent performances (check out `videos` folder)"""
@@ -44,7 +44,7 @@ class Args:
     """whether to save model into the `runs/{run_name}` folder"""
     evaluate: bool = False
     """if toggled, only runs evaluation with the given model checkpoint and saves the evaluation trajectories"""
-    checkpoint: str = None
+    checkpoint: Optional[str] = None
     """path to a pretrained checkpoint file to start evaluation/training from"""
     render_mode: str = "all"
     """the environment rendering mode"""

--- a/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
+++ b/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
@@ -121,6 +121,7 @@ class OpenCabinetDrawerEnv(BaseEnv):
                 self.scene, f"partnet-mobility:{model_id}"
             )
             cabinet_builder.set_scene_idxs(scene_idxs=[i])
+            cabinet_builder.initial_pose = sapien.Pose(p=[0, 0, 0], q=[1, 0, 0, 0])
             cabinet = cabinet_builder.build(name=f"{model_id}-{i}")
 
             # this disables self collisions by setting the group 2 bit at CABINET_COLLISION_BIT all the same

--- a/mani_skill/utils/building/ground.py
+++ b/mani_skill/utils/building/ground.py
@@ -34,6 +34,7 @@ def build_ground(
     ground.add_plane_collision(
         sapien.Pose(p=[0, 0, altitude], q=[0.7071068, 0, -0.7071068, 0]),
     )
+    ground.initial_pose = sapien.Pose(p=[0, 0, 0], q=[1, 0, 0, 0])
     if scene.parallel_in_single_scene:
         # when building a ground and using a parallel render in the GUI, we want to only build one ground visual+collision plane
         ground.set_scene_idxs([0])


### PR DESCRIPTION
change from #529 now ensure all objects created will have different initial poses on the GPU to ensure they definitely do not clash upon creating the objects. This actually fixes a bug in the articulated envs since the cabinets would open randomly but that was because during GPU init the robot collides with the cabinets since neither's initial pose has been set and so they default to the origin.

However this also means the collision mesh bounding box is now shifted unless the initial pose of the cabinet is set correctly.

Anyway it is now highly recommended in the docs to set initial poses of objects during loading to places you know they won't collide. Otherwise our code attempts to do it for you.