### PR TITLE
[BugFix]: improve perf for batched_rng

### DIFF
--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -879,12 +879,12 @@ class BaseEnv(gym.Env):
             self._episode_seed = common.to_numpy(seed, dtype=np.int64)
             if len(self._episode_seed) == 1 and self.num_envs > 1:
                 self._episode_seed = np.concatenate((self._episode_seed, np.random.RandomState(self._episode_seed[0]).randint(2**31, size=(self.num_envs - 1,))))
-        self._episode_rng = np.random.RandomState(self._episode_seed[0])
         # we keep _episode_rng for backwards compatibility but recommend using _batched_episode_rng for randomization
         if seed is not None or self._batched_episode_rng is None:
             self._batched_episode_rng = BatchedRNG.from_seeds(self._episode_seed, backend=self._batched_rng_backend)
         else:
             self._batched_episode_rng[env_idx] = BatchedRNG.from_seeds(self._episode_seed[env_idx], backend=self._batched_rng_backend)
+        self._episode_rng = self._batched_episode_rng[0]
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         """Initialize the episode, e.g., poses of actors and articulations, as well as task relevant data like randomizing

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -14,7 +14,6 @@ import sapien.render
 import sapien.utils.viewer.control_window
 import torch
 from gymnasium.vector.utils import batch_space
-
 from mani_skill import PACKAGE_ASSET_DIR, logger
 from mani_skill.agents import REGISTERED_AGENTS
 from mani_skill.agents.base_agent import BaseAgent
@@ -156,7 +155,7 @@ class BaseEnv(gym.Env):
     """the numpy RNG that you can use to generate random numpy data. It is not recommended to use this. Instead use the _batched_episode_rng which helps ensure GPU and CPU simulation generate the same data with the same seeds."""
     _batched_episode_rng: BatchedRNG = None
     """the recommended batched episode RNG to generate random numpy data consistently between single and parallel environments"""
-    _episode_seed: List[int] = None
+    _episode_seed: np.ndarray = None
     """episode seed list for _episode_rng and _batched_episode_rng. _episode_rng uses _episode_seed[0]."""
     _batched_rng_backend = "numpy:random_state"
     """the backend to use for the batched RNG"""
@@ -784,14 +783,21 @@ class BaseEnv(gym.Env):
         """
         if options is None:
             options = dict()
-        self._set_main_rng(seed)
-        # we first set the first episode seed to allow environments to use it to reconfigure the environment with a seed
-        self._set_episode_rng(seed)
-
         reconfigure = options.get("reconfigure", False)
         reconfigure = reconfigure or (
             self._reconfig_counter == 0 and self.reconfiguration_freq != 0
         )
+        if "env_idx" in options:
+            env_idx = options["env_idx"]
+            if len(env_idx) != self.num_envs and reconfigure:
+                raise RuntimeError("Cannot do a partial reset and reconfigure the environment. You must do one or the other.")
+        else:
+            env_idx = torch.arange(0, self.num_envs, device=self.device)
+
+        self._set_main_rng(seed)
+        # we first set the first episode seed to allow environments to use it to reconfigure the environment with a seed
+        self._set_episode_rng(seed, env_idx)
+
         if reconfigure:
             with torch.random.fork_rng():
                 torch.manual_seed(seed=self._episode_seed[0])
@@ -801,26 +807,17 @@ class BaseEnv(gym.Env):
         # TODO (stao): Reconfiguration when there is partial reset might not make sense and certainly broken here now.
         # Solution to resolve that would be to ensure tasks that do reconfigure more than once are single-env only / cpu sim only
         # or disable partial reset features explicitly for tasks that have a reconfiguration frequency
-        if "env_idx" in options:
-            env_idx = options["env_idx"]
-            if len(env_idx) != self.num_envs and reconfigure:
-                raise RuntimeError("Cannot do a partial reset and reconfigure the environment. You must do one or the other.")
-            self.scene._reset_mask = torch.zeros(
-                self.num_envs, dtype=bool, device=self.device
-            )
-            self.scene._reset_mask[env_idx] = True
-        else:
-            env_idx = torch.arange(0, self.num_envs, device=self.device)
-            self.scene._reset_mask = torch.ones(
-                self.num_envs, dtype=bool, device=self.device
-            )
+        self.scene._reset_mask = torch.zeros(
+            self.num_envs, dtype=torch.bool, device=self.device
+        )
+        self.scene._reset_mask[env_idx] = True
         self._elapsed_steps[env_idx] = 0
 
         self._clear_sim_state()
         if self.reconfiguration_freq != 0:
             self._reconfig_counter -= 1
         # Set the episode rng again after reconfiguration to guarantee seed reproducibility
-        self._set_episode_rng(self._episode_seed)
+        self._set_episode_rng(self._episode_seed, env_idx)
         if self.agent is not None:
             self.agent.reset()
         with torch.random.fork_rng():
@@ -868,19 +865,24 @@ class BaseEnv(gym.Env):
         if len(self._main_seed) == 1 and self.num_envs > 1:
             self._main_seed = self._main_seed + np.random.RandomState(self._main_seed[0]).randint(2**31, size=(self.num_envs - 1,)).tolist()
         self._batched_main_rng = BatchedRNG.from_seeds(self._main_seed, backend=self._batched_rng_backend)
-    def _set_episode_rng(self, seed: Union[None, list[int]]):
+
+    def _set_episode_rng(self, seed: Union[None, list[int]], env_idx: torch.Tensor):
         """Set the random generator for current episode."""
         if isinstance(seed, int):
             seed = [seed]
+        env_idx = common.to_numpy(env_idx)
         if seed is None:
-            self._episode_seed = self._batched_main_rng.randint(2**31).tolist()
+            self._episode_seed[env_idx] = self._batched_main_rng[env_idx].randint(2**31)
         else:
-            self._episode_seed = seed
-        if len(self._episode_seed) == 1 and self.num_envs > 1:
-            self._episode_seed = self._episode_seed + np.random.RandomState(self._episode_seed[0]).randint(2**31, size=(self.num_envs - 1,)).tolist()
+            self._episode_seed = common.to_numpy(seed, dtype=np.int64)
+            if len(self._episode_seed) == 1 and self.num_envs > 1:
+                self._episode_seed = np.concatenate((self._episode_seed, np.random.RandomState(self._episode_seed[0]).randint(2**31, size=(self.num_envs - 1,))))
         self._episode_rng = np.random.RandomState(self._episode_seed[0])
         # we keep _episode_rng for backwards compatibility but recommend using _batched_episode_rng for randomization
-        self._batched_episode_rng = BatchedRNG.from_seeds(self._episode_seed, backend=self._batched_rng_backend)
+        if seed is not None or self._batched_episode_rng is None:
+            self._batched_episode_rng = BatchedRNG.from_seeds(self._episode_seed, backend=self._batched_rng_backend)
+        else:
+            self._batched_episode_rng[env_idx] = BatchedRNG.from_seeds(self._episode_seed[env_idx], backend=self._batched_rng_backend)
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         """Initialize the episode, e.g., poses of actors and articulations, as well as task relevant data like randomizing

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -14,6 +14,7 @@ import sapien.render
 import sapien.utils.viewer.control_window
 import torch
 from gymnasium.vector.utils import batch_space
+
 from mani_skill import PACKAGE_ASSET_DIR, logger
 from mani_skill.agents import REGISTERED_AGENTS
 from mani_skill.agents.base_agent import BaseAgent
@@ -803,6 +804,8 @@ class BaseEnv(gym.Env):
                 torch.manual_seed(seed=self._episode_seed[0])
                 self._reconfigure(options)
                 self._after_reconfigure(options)
+            # Set the episode rng again after reconfiguration to guarantee seed reproducibility
+            self._set_episode_rng(self._episode_seed, env_idx)
 
         # TODO (stao): Reconfiguration when there is partial reset might not make sense and certainly broken here now.
         # Solution to resolve that would be to ensure tasks that do reconfigure more than once are single-env only / cpu sim only
@@ -816,8 +819,7 @@ class BaseEnv(gym.Env):
         self._clear_sim_state()
         if self.reconfiguration_freq != 0:
             self._reconfig_counter -= 1
-        # Set the episode rng again after reconfiguration to guarantee seed reproducibility
-        self._set_episode_rng(self._episode_seed, env_idx)
+
         if self.agent is not None:
             self.agent.reset()
         with torch.random.fork_rng():

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -867,7 +867,7 @@ class BaseEnv(gym.Env):
         self._main_rng = np.random.RandomState(self._main_seed[0])
         if len(self._main_seed) == 1 and self.num_envs > 1:
             self._main_seed = self._main_seed + np.random.RandomState(self._main_seed[0]).randint(2**31, size=(self.num_envs - 1,)).tolist()
-        self._batched_main_rng = BatchedRNG(self._main_seed, backend=self._batched_rng_backend)
+        self._batched_main_rng = BatchedRNG.from_seeds(self._main_seed, backend=self._batched_rng_backend)
     def _set_episode_rng(self, seed: Union[None, list[int]]):
         """Set the random generator for current episode."""
         if isinstance(seed, int):
@@ -880,7 +880,7 @@ class BaseEnv(gym.Env):
             self._episode_seed = self._episode_seed + np.random.RandomState(self._episode_seed[0]).randint(2**31, size=(self.num_envs - 1,)).tolist()
         self._episode_rng = np.random.RandomState(self._episode_seed[0])
         # we keep _episode_rng for backwards compatibility but recommend using _batched_episode_rng for randomization
-        self._batched_episode_rng = BatchedRNG(self._episode_seed, backend=self._batched_rng_backend)
+        self._batched_episode_rng = BatchedRNG.from_seeds(self._episode_seed, backend=self._batched_rng_backend)
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         """Initialize the episode, e.g., poses of actors and articulations, as well as task relevant data like randomizing

--- a/mani_skill/envs/scenes/base_env.py
+++ b/mani_skill/envs/scenes/base_env.py
@@ -83,9 +83,9 @@ class SceneManipulationEnv(BaseEnv):
         )
 
     def reset(self, seed=None, options=None):
-        self._set_episode_rng(seed)
         if options is None:
             options = dict(reconfigure=False)
+        self._set_episode_rng(seed, options.get("env_idx", torch.arange(self.num_envs)))
         if "reconfigure" in options and options["reconfigure"]:
             self.build_config_idxs = options.get(
                 "build_config_idxs", self.build_config_idxs

--- a/mani_skill/envs/utils/randomization/batched_rng.py
+++ b/mani_skill/envs/utils/randomization/batched_rng.py
@@ -7,6 +7,8 @@ from typing import List, Union
 
 import numpy as np
 
+from mani_skill.utils import common
+
 
 class BatchedRNG(np.random.RandomState):
     def __init__(self, rngs: List):
@@ -15,7 +17,6 @@ class BatchedRNG(np.random.RandomState):
 
     @classmethod
     def from_seeds(cls, seeds: List[int], backend: str = "numpy:random_state"):
-        batch_size = len(seeds)
         if backend == "numpy:random_state":
             return cls(rngs=[np.random.RandomState(seed) for seed in seeds])
         raise ValueError(f"Unknown batched RNG backend: {backend}")
@@ -25,9 +26,22 @@ class BatchedRNG(np.random.RandomState):
         return cls(rngs=rngs)
 
     def __getitem__(self, idx: Union[int, List[int], np.ndarray]):
+        idx = common.to_numpy(idx)
         if np.iterable(idx):
             return BatchedRNG.from_rngs([self.rngs[i] for i in idx])
         return self.rngs[idx]
+
+    def __setitem__(
+        self,
+        idx: Union[int, List[int], np.ndarray],
+        value: Union[np.random.RandomState, List[np.random.RandomState]],
+    ):
+        idx = common.to_numpy(idx)
+        if np.iterable(idx):
+            for i, new_v in zip(idx, value):
+                self.rngs[i] = new_v
+        else:
+            self.rngs[idx] = value
 
     def __getattribute__(self, item):
         if item in [

--- a/mani_skill/envs/utils/randomization/batched_rng.py
+++ b/mani_skill/envs/utils/randomization/batched_rng.py
@@ -2,18 +2,31 @@
 Code implementation for a batched random number generator. The goal is to enable seeding a batched random number generator with a batch of seeds to ensure randomization
 in CPU simulators and GPU simulators are the same
 """
+
+from typing import List, Union
+
 import numpy as np
 
 
 class BatchedRNG(np.random.RandomState):
-    def __init__(self, seeds: list[int], backend: str = "numpy:random_state"):
-        if backend == "numpy:random_state":
-            self.rngs = [np.random.RandomState(seed) for seed in seeds]
-        else:
-            raise ValueError(f"Unknown batched RNG backend: {backend}")
-        self.batch_size = len(seeds)
+    def __init__(self, rngs: List):
+        self.rngs = rngs
+        self.batch_size = len(rngs)
 
-    def __getitem__(self, idx: int):
+    @classmethod
+    def from_seeds(cls, seeds: List[int], backend: str = "numpy:random_state"):
+        batch_size = len(seeds)
+        if backend == "numpy:random_state":
+            return cls(rngs=[np.random.RandomState(seed) for seed in seeds])
+        raise ValueError(f"Unknown batched RNG backend: {backend}")
+
+    @classmethod
+    def from_rngs(cls, rngs: List):
+        return cls(rngs=rngs)
+
+    def __getitem__(self, idx: Union[int, List[int], np.ndarray]):
+        if np.iterable(idx):
+            return BatchedRNG.from_rngs([self.rngs[i] for i in idx])
         return self.rngs[idx]
 
     def __getattribute__(self, item):

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -74,8 +74,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )
@@ -89,8 +89,8 @@ class TableSceneBuilder(SceneBuilder):
             )
             # fmt: on
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )
@@ -102,8 +102,8 @@ class TableSceneBuilder(SceneBuilder):
                 [0, np.pi / 6, 0, np.pi / 3, 0, np.pi / 2, -np.pi / 2, 0, 0]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )
@@ -152,8 +152,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )
@@ -182,8 +182,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )
@@ -216,8 +216,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx].normal(
-                    0, self.robot_init_qpos_noise, len(qpos)
+                self.env._episode_rng.normal(
+                    0, self.robot_init_qpos_noise, (b, len(qpos))
                 )
                 + qpos
             )

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -74,7 +74,7 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
@@ -89,7 +89,7 @@ class TableSceneBuilder(SceneBuilder):
             )
             # fmt: on
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
@@ -102,7 +102,7 @@ class TableSceneBuilder(SceneBuilder):
                 [0, np.pi / 6, 0, np.pi / 3, 0, np.pi / 2, -np.pi / 2, 0, 0]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
@@ -152,7 +152,7 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
@@ -182,7 +182,7 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
@@ -216,7 +216,7 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                self.env._batched_episode_rng[env_idx].normal(
                     0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -73,12 +73,20 @@ class TableSceneBuilder(SceneBuilder):
                     0.04,
                 ]
             )
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             qpos[:, -2:] = 0.04
             self.env.agent.reset(qpos)
             self.env.agent.robot.set_pose(sapien.Pose([-0.615, 0, 0]))
@@ -88,12 +96,20 @@ class TableSceneBuilder(SceneBuilder):
                 [0.0, np.pi / 8, 0, -np.pi * 5 / 8, 0, np.pi * 3 / 4, -np.pi / 4, 0.04, 0.04]
             )
             # fmt: on
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             qpos[:, -2:] = 0.04
             self.env.agent.reset(qpos)
             self.env.agent.robot.set_pose(sapien.Pose([-0.615, 0, 0]))
@@ -101,12 +117,20 @@ class TableSceneBuilder(SceneBuilder):
             qpos = np.array(
                 [0, np.pi / 6, 0, np.pi / 3, 0, np.pi / 2, -np.pi / 2, 0, 0]
             )
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             qpos[:, -2:] = 0
             self.env.agent.reset(qpos)
             self.env.agent.robot.set_pose(sapien.Pose([-0.562, 0, 0]))
@@ -151,12 +175,20 @@ class TableSceneBuilder(SceneBuilder):
                     0.04,
                 ]
             )
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             qpos[:, -2:] = 0.04
             agent.agents[1].reset(qpos)
             agent.agents[1].robot.set_pose(
@@ -181,12 +213,20 @@ class TableSceneBuilder(SceneBuilder):
                     0.04,
                 ]
             )
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             qpos[:, -2:] = 0.04
             agent.agents[1].reset(qpos)
             agent.agents[1].robot.set_pose(
@@ -215,11 +255,19 @@ class TableSceneBuilder(SceneBuilder):
                     np.pi / 4,
                 ]
             )
-            qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+            if self.env._enhanced_determinism:
+                qpos = (
+                    self.env._batched_episode_rng[env_idx].normal(
+                        0, self.robot_init_qpos_noise, len(qpos)
+                    )
+                    + qpos
                 )
-                + qpos
-            )
+            else:
+                qpos = (
+                    self.env._episode_rng.normal(
+                        0, self.robot_init_qpos_noise, (b, len(qpos))
+                    )
+                    + qpos
+                )
             self.env.agent.reset(qpos)
             self.env.agent.robot.set_pose(sapien.Pose([-0.615, 0, 0]))

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -74,8 +74,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )
@@ -89,8 +89,8 @@ class TableSceneBuilder(SceneBuilder):
             )
             # fmt: on
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )
@@ -102,8 +102,8 @@ class TableSceneBuilder(SceneBuilder):
                 [0, np.pi / 6, 0, np.pi / 3, 0, np.pi / 2, -np.pi / 2, 0, 0]
             )
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )
@@ -152,8 +152,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )
@@ -182,8 +182,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )
@@ -216,8 +216,8 @@ class TableSceneBuilder(SceneBuilder):
                 ]
             )
             qpos = (
-                self.env._episode_rng.normal(
-                    0, self.robot_init_qpos_noise, (b, len(qpos))
+                self.env._batched_episode_rng[env_idx.tolist()].normal(
+                    0, self.robot_init_qpos_noise, len(qpos)
                 )
                 + qpos
             )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,8 +26,8 @@ do
         "haosulab/mani-skill2_py$PYTHON_VERSION"
     # uninstall the pypi mani_skill2, install the local version and pytest, then run pytest
     echo "Installing Dependencies"
-    docker exec ${container_name} /bin/bash -c "cd ~ && pip uninstall -y mani_skill2 && pip install -e . && pip install pytest-xdist[psutil]" > /dev/null 2>&1
-    docker exec ${container_name} /bin/bash -c "cd ~ && pytest -n auto tests"
+    docker exec ${container_name} /bin/bash -c "cd ~ && pip uninstall -y mani_skill2 && pip install -e .[dev]" > /dev/null 2>&1
+    docker exec ${container_name} /bin/bash -c "cd ~ && pytest -n auto --forked tests"
     docker container stop ${container_name}
     docker container rm ${container_name}
 done


### PR DESCRIPTION
- [x] set batchrng by env_idx when resetting
- [x] double-set seeds only if reconfiguring
- [x] allow set batchrng with env_idx
- [x] allow call batchrng with env_idx
- [x] use batchrng with env_idx for table scene builder robot init
- [x] enchanced_determinism option

<p>
<em>grey: b10, purple: latest::enhanced_determinism=<b>off</b>, blue: latest::enhanced_determinism=<b>on</b></em>
<img width="392" alt="image" src="https://github.com/user-attachments/assets/88953553-9755-4c3f-b39c-5a23fc7390b8">
</p>
