### PR TITLE
[Feature] Refactor the use of  physx.is_gpu_enabled and make common.to_tensor move to torch without assuming device

### DIFF
--- a/examples/baselines/ppo/examples.sh
+++ b/examples/baselines/ppo/examples.sh
@@ -40,7 +40,7 @@ python ppo.py --env_id="TriFingerRotateCubeLevel4-v1" \
    --num_envs=1024 --update_epochs=8 --num_minibatches=32 \
    --total_timesteps=500_000_000 --num-steps=250 --num-eval-steps=250
 python ppo.py --env_id="PokeCube-v1" --update_epochs=8 --num_minibatches=32 \
-  --num_envs=1024 --total_timesteps=3_000_000 --eval_freq=10 --num-steps=20
+  --num_envs=1024 --total_timesteps=5_000_000 --eval_freq=10 --num-steps=20
 python ppo.py --env_id="MS-CartpoleBalance-v1" \
    --num_envs=1024 --update_epochs=8 --num_minibatches=32 \
    --total_timesteps=4_000_000 --num-steps=250 --num-eval-steps=1000 \

--- a/mani_skill/agents/base_agent.py
+++ b/mani_skill/agents/base_agent.py
@@ -278,7 +278,7 @@ class BaseAgent:
         Set the agent's action which is to be executed in the next environment timestep.
         This is essentially a wrapper around the controller's set_action method.
         """
-        if not physx.is_gpu_enabled():
+        if not self.scene.gpu_sim_enabled:
             if np.isnan(action).any():
                 raise ValueError("Action cannot be NaN. Environment received:", action)
         self.controller.set_action(action)

--- a/mani_skill/agents/controllers/base_controller.py
+++ b/mani_skill/agents/controllers/base_controller.py
@@ -82,7 +82,7 @@ class BaseController:
             self.joints = get_joints_by_names(self.articulation, joint_names)
             self.active_joint_indices = get_active_joint_indices(
                 self.articulation, joint_names
-            )
+            ).to(self.device)
         except Exception as err:
             print("Encounter error when parsing joint names.")
             active_joint_names = [x.name for x in self.articulation.get_active_joints()]
@@ -160,8 +160,8 @@ class BaseController:
             self._original_single_action_space.low,
             self._original_single_action_space.high,
         )
-        self.action_space_low = common.to_tensor(low)
-        self.action_space_high = common.to_tensor(high)
+        self.action_space_low = common.to_tensor(low, device=self.device)
+        self.action_space_high = common.to_tensor(high, device=self.device)
 
     def _clip_and_scale_action(self, action):
         return gym_utils.clip_and_scale_action(
@@ -238,7 +238,7 @@ class DictController(BaseController):
 
     def set_action(self, action: Dict[str, np.ndarray]):
         for uid, controller in self.controllers.items():
-            controller.set_action(common.to_tensor(action[uid]))
+            controller.set_action(action[uid])
 
     def get_state(self) -> dict:
         states = {}
@@ -257,7 +257,7 @@ class DictController(BaseController):
         This can be useful for joint position control when setting a desired qposition even
         if some controllers merge some joints together like the mimic controller
         """
-        qpos = common.to_tensor(qpos)
+        qpos = common.to_tensor(qpos, device=self.device)
         if len(qpos.shape) > 1:
             assert qpos.shape[1] == len(self.joints)
         else:

--- a/mani_skill/agents/controllers/pd_joint_pos.py
+++ b/mani_skill/agents/controllers/pd_joint_pos.py
@@ -72,7 +72,6 @@ class PDJointPosController(BaseController):
 
     def set_action(self, action: Array):
         action = self._preprocess_action(action)
-        action = common.to_tensor(action)
         self._step = 0
         self._start_qpos = self.qpos
         if self.config.use_delta:

--- a/mani_skill/agents/robots/allegro_hand/allegro_touch.py
+++ b/mani_skill/agents/robots/allegro_hand/allegro_touch.py
@@ -60,7 +60,7 @@ class AllegroHandRightTouch(AllegroHandRight):
         )
 
     def get_fsr_obj_impulse(self, obj: Actor = None):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             px: physx.PhysxGpuSystem = self.scene.px
             # Create contact query if it is not existed
             if obj.name not in self.pair_query:
@@ -102,7 +102,7 @@ class AllegroHandRightTouch(AllegroHandRight):
             return np.stack(contact_forces)
 
     def get_fsr_impulse(self):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             px: physx.PhysxGpuSystem = self.scene.px
             # Create contact query if it is not existed
             if self.body_query is None:

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -212,9 +212,9 @@ class BaseEnv(gym.Env):
             if self.robot_uids not in self.SUPPORTED_ROBOTS:
                 logger.warn(f"{self.robot_uids} is not in the task's list of supported robots. Code may not run as intended")
 
-        if physx.is_gpu_enabled() and num_envs == 1 and (sim_backend == "auto" or sim_backend == "cpu"):
-            logger.warn("GPU simulation has already been enabled on this process, switching to GPU backend")
-            sim_backend == "gpu"
+        # if self.gpu_sim_enabled and num_envs == 1 and (sim_backend == "auto" or sim_backend == "cpu"):
+        #     logger.warn("GPU simulation has already been enabled on this process, switching to GPU backend")
+        #     sim_backend == "gpu"
 
         # determine the sim and render devices
         if sim_backend == "auto":
@@ -373,8 +373,8 @@ class BaseEnv(gym.Env):
 
     @property
     def gpu_sim_enabled(self):
-        """Whether the gpu simulation is enabled. A wrapper over physx.is_gpu_enabled()"""
-        return physx.is_gpu_enabled()
+        """Whether the gpu simulation is enabled."""
+        return self.scene.gpu_sim_enabled
 
     @property
     def _default_sim_config(self):
@@ -830,7 +830,7 @@ class BaseEnv(gym.Env):
         self.scene._reset_mask = torch.ones(
             self.num_envs, dtype=bool, device=self.device
         )
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             # ensure all updates to object poses and configurations are applied on GPU after task initialization
             self.scene._gpu_apply_all()
             self.scene.px.gpu_update_articulation_kinematics()
@@ -891,13 +891,13 @@ class BaseEnv(gym.Env):
         """Clear simulation state (velocities)"""
         for actor in self.scene.actors.values():
             if actor.px_body_type == "dynamic":
-                actor.set_linear_velocity([0., 0., 0.])
-                actor.set_angular_velocity([0., 0., 0.])
+                actor.set_linear_velocity(torch.zeros(3, device=self.device))
+                actor.set_angular_velocity(torch.zeros(3, device=self.device))
         for articulation in self.scene.articulations.values():
-            articulation.set_qvel(np.zeros(articulation.max_dof))
-            articulation.set_root_linear_velocity([0., 0., 0.])
-            articulation.set_root_angular_velocity([0., 0., 0.])
-        if physx.is_gpu_enabled():
+            articulation.set_qvel(torch.zeros(articulation.max_dof, device=self.device))
+            articulation.set_root_linear_velocity(torch.zeros(3, device=self.device))
+            articulation.set_root_angular_velocity(torch.zeros(3, device=self.device))
+        if self.gpu_sim_enabled:
             self.scene._gpu_apply_all()
             self.scene._gpu_fetch_all()
             # TODO (stao): This may be an unnecessary fetch and apply.
@@ -945,7 +945,7 @@ class BaseEnv(gym.Env):
         if action is None:  # simulation without action
             pass
         elif isinstance(action, np.ndarray) or isinstance(action, torch.Tensor):
-            action = common.to_tensor(action)
+            action = common.to_tensor(action, device=self.device)
             if action.shape == self._orig_single_action_space.shape:
                 action_is_unbatched = True
             set_action = True
@@ -954,13 +954,13 @@ class BaseEnv(gym.Env):
                 if action["control_mode"] != self.agent.control_mode:
                     self.agent.set_control_mode(action["control_mode"])
                     self.agent.controller.reset()
-                action = common.to_tensor(action["action"])
+                action = common.to_tensor(action["action"], device=self.device)
             else:
                 assert isinstance(
                     self.agent, MultiAgent
                 ), "Received a dictionary for an action but there are not multiple robots in the environment"
                 # assume this is a multi-agent action
-                action = common.to_tensor(action)
+                action = common.to_tensor(action, device=self.device)
                 for k, a in action.items():
                     if a.shape == self._orig_single_action_space[k].shape:
                         action_is_unbatched = True
@@ -984,7 +984,7 @@ class BaseEnv(gym.Env):
             self.scene.step()
             self._after_simulation_step()
         self._after_control_step()
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             self.scene._gpu_fetch_all()
         return action
 
@@ -1006,7 +1006,7 @@ class BaseEnv(gym.Env):
         """
         info = dict(
             elapsed_steps=self.elapsed_steps
-            if not physx.is_gpu_enabled()
+            if not self.gpu_sim_enabled
             else self._elapsed_steps.clone()
         )
         info.update(self.evaluate())
@@ -1131,7 +1131,7 @@ class BaseEnv(gym.Env):
         `env.get_state_dict()` or the result of `env.get_state()`
         """
         self.scene.set_sim_state(state, env_idx)
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             self.scene._gpu_apply_all()
             self.scene.px.gpu_update_articulation_kinematics()
             self.scene._gpu_fetch_all()
@@ -1191,7 +1191,7 @@ class BaseEnv(gym.Env):
         if self._viewer is None:
             self._viewer = create_viewer(self._viewer_camera_config)
             self._setup_viewer()
-        if physx.is_gpu_enabled() and self.scene._gpu_sim_initialized:
+        if self.gpu_sim_enabled and self.scene._gpu_sim_initialized:
             self.scene.px.sync_poses_gpu_to_cpu()
         self._viewer.render()
         for obj in self._hidden_objects:
@@ -1309,7 +1309,7 @@ class BaseEnv(gym.Env):
                 config = cam.config
                 sensor_settings_str.append(f"RGBD({config.width}x{config.height})")
         sensor_settings_str = ", ".join(sensor_settings_str)
-        sim_backend = "gpu" if physx.is_gpu_enabled() else "cpu"
+        sim_backend = "gpu" if self.gpu_sim_enabled else "cpu"
         print(
         "# -------------------------------------------------------------------------- #"
         )

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -153,7 +153,7 @@ class ManiSkillScene:
 
     def remove_actor(self, actor: Actor):
         """Removes an actor from the scene. Only works in CPU simulation."""
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             raise NotImplementedError(
                 "Cannot remove actors after creating them in GPU sim at the moment"
             )
@@ -163,7 +163,7 @@ class ManiSkillScene:
 
     def remove_articulation(self, articulation: Articulation):
         """Removes an articulation from the scene. Only works in CPU simulation."""
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             raise NotImplementedError(
                 "Cannot remove articulations after creating them in GPU sim at the moment"
             )
@@ -244,7 +244,7 @@ class ManiSkillScene:
 
             # mount camera to actor/link
             if mount is not None:
-                if physx.is_gpu_enabled():
+                if self.gpu_sim_enabled:
                     if isinstance(mount, Actor):
                         camera.set_gpu_pose_batch_index(
                             mount._objs[i]
@@ -364,7 +364,7 @@ class ManiSkillScene:
             self._sapien_update_render()
 
     def _sapien_update_render(self):
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             if not self.parallel_in_single_scene:
                 if self.render_system_group is None:
                     self._setup_gpu_rendering()
@@ -378,7 +378,7 @@ class ManiSkillScene:
             self.sub_scenes[0].update_render()
 
     def _sapien_31_update_render(self):
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             if self.render_system_group is None:
                 # TODO (stao): for new render system support the parallel in single scene rendering option
                 for scene in self.sub_scenes:
@@ -699,7 +699,7 @@ class ManiSkillScene:
         # TODO (stao): Is there any optimization improvement when putting all queries all together and fetched together
         # vs multiple smaller queries? If so, might be worth exposing a helpful API for that instead of having user
         # write this code below themselves.
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             query_hash = hash((obj1, obj2))
             query_key = obj1.name + obj2.name
 
@@ -1039,7 +1039,7 @@ class ManiSkillScene:
         self, camera_name: str = None
     ) -> Dict[str, torch.Tensor]:
         image_data = dict()
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             if self.parallel_in_single_scene:
                 for name, camera in self.human_render_cameras.items():
                     camera.camera._render_cameras[0].take_picture()

--- a/mani_skill/envs/scenes/base_env.py
+++ b/mani_skill/envs/scenes/base_env.py
@@ -109,6 +109,9 @@ class SceneManipulationEnv(BaseEnv):
             return
         return super()._load_lighting(options)
 
+    def _load_agent(self, options: dict):
+        super()._load_agent(options, sapien.Pose())
+
     def _load_scene(self, options: dict):
         if self.scene_builder.build_configs is not None:
             self.scene_builder.build(

--- a/mani_skill/envs/tasks/control/ant.py
+++ b/mani_skill/envs/tasks/control/ant.py
@@ -181,7 +181,7 @@ class AntEnv(BaseEnv):
             Pose.create_from_pq(p=self.agent.robot.links_map["torso"].pose.p)
         )
         # gpu requires that we manually apply this update
-        if sapien.physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             # we update just actor pose here, no need to call apply_all/fetch_all
             self.scene.px.gpu_apply_rigid_dynamic_data()
             self.scene.px.gpu_fetch_rigid_dynamic_data()

--- a/mani_skill/envs/tasks/control/humanoid.py
+++ b/mani_skill/envs/tasks/control/humanoid.py
@@ -76,7 +76,7 @@ class HumanoidEnvBase(BaseEnv):
         self.camera_mount.set_pose(
             Pose.create_from_pq(p=self.agent.robot.links_map["torso"].pose.p)
         )
-        if sapien.physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             # we update just actor pose here, no need to call apply_all/fetch_all
             self.scene.px.gpu_apply_rigid_dynamic_data()
             self.scene.px.gpu_fetch_rigid_dynamic_data()

--- a/mani_skill/envs/tasks/dexterity/rotate_single_object_in_hand.py
+++ b/mani_skill/envs/tasks/dexterity/rotate_single_object_in_hand.py
@@ -144,7 +144,7 @@ class RotateSingleObjectInHand(BaseEnv):
 
         if self.difficulty_level < 2:
             # for levels 0 and 1 we already know object heights. For other levels we need to compute them
-            self.obj_heights = common.to_tensor(obj_heights)
+            self.obj_heights = common.to_tensor(obj_heights, device=self.device)
 
     def _after_reconfigure(self, options: dict):
         if self.difficulty_level >= 2:
@@ -153,7 +153,7 @@ class RotateSingleObjectInHand(BaseEnv):
                 collision_mesh = obj.get_first_collision_mesh()
                 # this value is used to set object pose so the bottom is at z=0
                 self.obj_heights.append(-collision_mesh.bounding_box.bounds[0, 2])
-            self.obj_heights = common.to_tensor(self.obj_heights)
+            self.obj_heights = common.to_tensor(self.obj_heights, device=self.device)
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         self._initialize_actors(env_idx)

--- a/mani_skill/envs/tasks/digital_twins/base_env.py
+++ b/mani_skill/envs/tasks/digital_twins/base_env.py
@@ -98,7 +98,7 @@ class BaseDigitalTwinEnv(BaseEnv):
                     self._rgb_overlay_images[camera_name], (sensor.width, sensor.height)
                 )
                 self._rgb_overlay_images[camera_name] = common.to_tensor(
-                    rgb_overlay_img
+                    rgb_overlay_img, device=self.device
                 )
 
     def _green_sceen_rgb(self, rgb, segmentation, overlay_img):

--- a/mani_skill/envs/tasks/digital_twins/bridge_dataset_eval/base_env.py
+++ b/mani_skill/envs/tasks/digital_twins/bridge_dataset_eval/base_env.py
@@ -296,8 +296,12 @@ class BaseBridgeEnv(BaseDigitalTwinEnv):
         for name in self.obj_names:
             self.objs[name] = self._build_actor_helper(name)
 
-        self.xyz_configs = common.to_tensor(self.xyz_configs).to(torch.float32)
-        self.quat_configs = common.to_tensor(self.quat_configs).to(torch.float32)
+        self.xyz_configs = common.to_tensor(self.xyz_configs, device=self.device).to(
+            torch.float32
+        )
+        self.quat_configs = common.to_tensor(self.quat_configs, device=self.device).to(
+            torch.float32
+        )
 
         if self.scene_setting == "sink":
             self.sink = self._build_actor_helper(
@@ -316,6 +320,7 @@ class BaseBridgeEnv(BaseDigitalTwinEnv):
                 if this_available_model_scales is None:
                     model_scales.append(1.0)
                 else:
+                    # TODO (stao): use the batched RNG
                     model_scales[model_id] = self.np_random.choice(
                         this_available_model_scales
                     )
@@ -327,7 +332,9 @@ class BaseBridgeEnv(BaseDigitalTwinEnv):
             if "bbox" in model_info:
                 bbox = model_info["bbox"]
                 bbox_size = np.array(bbox["max"]) - np.array(bbox["min"])
-                model_bbox_sizes[model_id] = common.to_tensor(bbox_size * model_scale)
+                model_bbox_sizes[model_id] = common.to_tensor(
+                    bbox_size * model_scale, device=self.device
+                )
             else:
                 raise ValueError(f"Model {model_id} does not have bbox info.")
         self.episode_model_bbox_sizes = model_bbox_sizes

--- a/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
+++ b/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
@@ -276,13 +276,13 @@ class OpenCabinetDrawerEnv(BaseEnv):
         # after each control step, we update the goal position of the handle link
         # for GPU sim we need to update the kinematics data to get latest pose information for up to date link poses
         # and fetch it, followed by an apply call to ensure the GPU sim is up to date
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             self.scene.px.gpu_update_articulation_kinematics()
             self.scene._gpu_fetch_all()
         self.handle_link_goal.set_pose(
             Pose.create_from_pq(p=self.handle_link_positions())
         )
-        if physx.is_gpu_enabled():
+        if self.gpu_sim_enabled:
             self.scene._gpu_apply_all()
 
     def evaluate(self):

--- a/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
+++ b/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
@@ -121,7 +121,7 @@ class PickSingleYCBEnv(BaseEnv):
             collision_mesh = obj.get_first_collision_mesh()
             # this value is used to set object pose so the bottom is at z=0
             self.object_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
-        self.object_zs = common.to_tensor(self.object_zs)
+        self.object_zs = common.to_tensor(self.object_zs, device=self.device)
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         with torch.device(self.device):

--- a/mani_skill/envs/tasks/tabletop/poke_cube.py
+++ b/mani_skill/envs/tasks/tabletop/poke_cube.py
@@ -202,7 +202,7 @@ class PokeCubeEnv(BaseEnv):
         static_reward = 1 - torch.tanh(
             5 * torch.linalg.norm(self.agent.robot.get_qvel()[..., :-2], axis=1)
         )
-        reward[info["is_cube_placed"]] += static_reward
+        reward[info["is_cube_placed"]] += static_reward[info["is_cube_placed"]]
 
         reward[info["success"]] = 10
         return reward

--- a/mani_skill/envs/tasks/tabletop/poke_cube.py
+++ b/mani_skill/envs/tasks/tabletop/poke_cube.py
@@ -77,9 +77,12 @@ class PokeCubeEnv(BaseEnv):
             name="goal_region",
             add_collision=False,
             body_type="kinematic",
+            initial_pose=sapien.Pose(),
         )
 
-        self.peg_head_offsets = Pose.create_from_pq(p=[self.peg_half_length, 0, 0])
+        self.peg_head_offsets = Pose.create_from_pq(
+            p=[self.peg_half_length, 0, 0], device=self.device
+        )
 
     @property
     def peg_head_pos(self):
@@ -161,9 +164,9 @@ class PokeCubeEnv(BaseEnv):
 
         is_peg_cube_fit = torch.logical_and(is_peg_cube_aligned, is_peg_cube_close)
         is_peg_grasped = self.agent.is_grasping(self.peg)
-        close_to_table = torch.abs(self.peg.pose.p[:, 2] - self.peg_half_width) < 0.005
+        # close_to_table = torch.abs(self.peg.pose.p[:, 2] - self.peg_half_width) < 0.005
         return {
-            "success": is_cube_placed & is_peg_cube_fit & close_to_table,
+            "success": is_cube_placed,
             "is_peg_cube_fit": is_peg_cube_fit,
             "is_peg_grasped": is_peg_grasped,
             "angle_diff": angle_diff,

--- a/mani_skill/envs/tasks/tabletop/stack_cube.py
+++ b/mani_skill/envs/tasks/tabletop/stack_cube.py
@@ -37,7 +37,7 @@ class StackCubeEnv(BaseEnv):
         return CameraConfig("render_camera", pose, 512, 512, 1, 0.01, 100)
 
     def _load_scene(self, options: dict):
-        self.cube_half_size = common.to_tensor([0.02] * 3)
+        self.cube_half_size = common.to_tensor([0.02] * 3, device=self.device)
         self.table_scene = TableSceneBuilder(
             env=self, robot_init_qpos_noise=self.robot_init_qpos_noise
         )
@@ -58,7 +58,9 @@ class StackCubeEnv(BaseEnv):
             xyz[:, 2] = 0.02
             xy = torch.rand((b, 2)) * 0.2 - 0.1
             region = [[-0.1, -0.2], [0.1, 0.2]]
-            sampler = randomization.UniformPlacementSampler(bounds=region, batch_size=b)
+            sampler = randomization.UniformPlacementSampler(
+                bounds=region, batch_size=b, device=self.device
+            )
             radius = torch.linalg.norm(torch.tensor([0.02, 0.02])) + 0.001
             cubeA_xy = xy + sampler.sample(radius, 100)
             cubeB_xy = xy + sampler.sample(radius, 100, verbose=False)

--- a/mani_skill/envs/tasks/tabletop/turn_faucet.py
+++ b/mani_skill/envs/tasks/tabletop/turn_faucet.py
@@ -153,7 +153,7 @@ class TurnFaucetEnv(BaseEnv):
             self.faucet.set_pose(Pose.create_from_pq(p, q))
 
             # apply pose changes and update kinematics to get updated link poses.
-            if physx.is_gpu_enabled():
+            if self.gpu_sim_enabled:
                 self.scene._gpu_apply_all()
                 self.scene.px.gpu_update_articulation_kinematics()
                 self.scene.px.step()

--- a/mani_skill/envs/tasks/tabletop/two_robot_stack_cube.py
+++ b/mani_skill/envs/tasks/tabletop/two_robot_stack_cube.py
@@ -79,7 +79,7 @@ class TwoRobotStackCube(BaseEnv):
         return CameraConfig("render_camera", pose, 512, 512, 1, 0.01, 100)
 
     def _load_scene(self, options: dict):
-        self.cube_half_size = common.to_tensor([0.02] * 3)
+        self.cube_half_size = common.to_tensor([0.02] * 3, device=self.device)
         self.table_scene = TableSceneBuilder(
             env=self, robot_init_qpos_noise=self.robot_init_qpos_noise
         )

--- a/mani_skill/envs/utils/randomization/samplers.py
+++ b/mani_skill/envs/utils/randomization/samplers.py
@@ -7,6 +7,7 @@ from typing import List, Tuple
 import torch
 
 from mani_skill.utils import common
+from mani_skill.utils.geometry.rotation_conversions import Device
 
 
 class UniformPlacementSampler:
@@ -19,10 +20,13 @@ class UniformPlacementSampler:
     """
 
     def __init__(
-        self, bounds: Tuple[List[float], List[float]], batch_size: int
+        self,
+        bounds: Tuple[List[float], List[float]],
+        batch_size: int,
+        device: Device = None,
     ) -> None:
         assert len(bounds) == 2 and len(bounds[0]) == len(bounds[1])
-        self._bounds = common.to_tensor(bounds)
+        self._bounds = common.to_tensor(bounds, device=device)
         self._ranges = self._bounds[1] - self._bounds[0]
         self.fixtures_radii = None
         self.fixture_positions = None

--- a/mani_skill/utils/building/actor_builder.py
+++ b/mani_skill/utils/building/actor_builder.py
@@ -272,7 +272,7 @@ class ActorBuilder(SAPIENActorBuilder):
         if (
             self.physx_body_type == "static"
             and initial_pose_b == 1
-            and physx.is_gpu_enabled()
+            and self.scene.gpu_sim_enabled
         ):
             actor.initial_pose = Pose.create(
                 self.initial_pose.raw_pose.repeat(num_actors, 1)

--- a/mani_skill/utils/building/articulation_builder.py
+++ b/mani_skill/utils/building/articulation_builder.py
@@ -132,7 +132,9 @@ class ArticulationBuilder(SapienArticulationBuilder):
         num_arts = len(self.scene_idxs)
 
         if self.initial_pose is None:
-            initial_ps = []
+            initial_ps = torch.zeros(
+                (len(self.scene_idxs), 3), device=self.scene.device
+            )
             for scene_idx in self.scene_idxs:
                 if self.scene.parallel_in_single_scene:
                     sub_scene = self.scene.sub_scenes[0]
@@ -143,10 +145,14 @@ class ArticulationBuilder(SapienArticulationBuilder):
                 z_height = SPAWN_SPACING * (entity_num // 2 + 1) + SPAWN_START_GAP
                 # zdir, switch between -1 and 1 to flip above and below origin
                 z_height *= 2 * (entity_num % 2) - 1
-                initial_ps.append([0, 0, z_height])
-            self.initial_pose = Pose.create_from_pq(p=initial_ps)
+                initial_ps[scene_idx] = torch.tensor(
+                    [0, 0, z_height], device=self.scene.device
+                )
+            self.initial_pose = Pose.create_from_pq(
+                p=initial_ps, device=self.scene.device
+            )
         else:
-            self.initial_pose = Pose.create(self.initial_pose)
+            self.initial_pose = Pose.create(self.initial_pose, device=self.scene.device)
         initial_pose_b = self.initial_pose.raw_pose.shape[0]
         assert initial_pose_b == 1 or initial_pose_b == num_arts
         initial_pose_np = common.to_numpy(self.initial_pose.raw_pose)

--- a/mani_skill/utils/building/urdf_loader.py
+++ b/mani_skill/utils/building/urdf_loader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import TYPE_CHECKING, Any, List, TypedDict
 
 from sapien.render import RenderCameraComponent
 from sapien.wrapper.urdf_loader import URDFLoader as SapienURDFLoader
@@ -14,14 +14,18 @@ if TYPE_CHECKING:
     from mani_skill.envs.scene import ManiSkillScene
 
 
+class ParsedURDFData(TypedDict):
+    articulation_builders: List[ArticulationBuilder]
+    actor_builders: List[ActorBuilder]
+    cameras: List[Any]
+
+
 class URDFLoader(SapienURDFLoader):
     scene: ManiSkillScene
     name: str = None
     disable_self_collisions: bool = False
 
-    def parse(
-        self, urdf_file, srdf_file=None, package_dir=None
-    ) -> Tuple[List[ArticulationBuilder], List[ActorBuilder], List[Any]]:
+    def parse(self, urdf_file, srdf_file=None, package_dir=None) -> ParsedURDFData:
         articulation_builders, actor_builders, cameras = super().parse(
             urdf_file, srdf_file, package_dir
         )

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -147,6 +147,8 @@ def to_tensor(array: Array, device: Optional[Device] = None):
             array = array.astype(np.int64)
         ret = torch.tensor(array).to(device)
     else:
+        if isinstance(array, list) and isinstance(array[0], np.ndarray):
+            array = np.array(array)
         ret = torch.tensor(array, device=device)
     if ret.dtype == torch.float64:
         ret = ret.to(torch.float32)

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -143,6 +143,8 @@ def to_tensor(array: Array, device: Optional[Device] = None):
         # TODO (stao): check of doing .to(device) is slow even if its just CPU
         if array.dtype == np.uint16:
             array = array.astype(np.int32)
+        elif array.dtype == np.uint32:
+            array = array.astype(np.int64)
         ret = torch.from_numpy(array).to(device)
         if ret.dtype == torch.float64:
             ret = ret.to(torch.float32)

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -137,46 +137,56 @@ def to_tensor(array: Array, device: Optional[Device] = None):
     """
     if isinstance(array, (dict)):
         return {k: to_tensor(v, device=device) for k, v in array.items()}
-    if physx.is_gpu_enabled():
-        if isinstance(array, np.ndarray):
-            if array.dtype == np.uint16:
-                array = array.astype(np.int32)
-            ret = torch.from_numpy(array)
-            if ret.dtype == torch.float64:
-                ret = ret.float()
-        elif isinstance(array, torch.Tensor):
-            ret = array
-        else:
-            ret = torch.tensor(array)
-        if device is None:
-            if ret.device.type == "cpu":
-                # TODO (stao): note that .cuda does move a tensor to the torch.device context, it moves to the default
-                return ret.cuda()
-            # keep same device if already on GPU
-            return ret
-        else:
-            return ret.to(device)
+    elif isinstance(array, torch.Tensor):
+        ret = array.to(device)
+    elif isinstance(array, np.ndarray):
+        # TODO (stao): check of doing .to(device) is slow even if its just CPU
+        ret = torch.from_numpy(array).to(device)
     else:
-        if isinstance(array, np.ndarray):
-            if array.dtype == np.uint16:
-                array = array.astype(np.int32)
-            if array.dtype == np.uint32:
-                array = array.astype(np.int64)
-            ret = torch.from_numpy(array)
-            if ret.dtype == torch.float64:
-                ret = ret.float()
-        elif isinstance(array, list) and isinstance(array[0], np.ndarray):
-            ret = torch.from_numpy(np.array(array))
-            if ret.dtype == torch.float64:
-                ret = ret.float()
-        elif np.iterable(array):
-            ret = torch.Tensor(array)
-        else:
-            ret = torch.Tensor(array)
-        if device is None:
-            return ret
-        else:
-            return ret.to(device)
+        ret = torch.tensor(array, device=device)
+    if ret.dtype == torch.float64:
+        ret = ret.float()
+    return ret
+    # if physx.is_gpu_enabled():
+    #     if isinstance(array, np.ndarray):
+    #         if array.dtype == np.uint16:
+    #             array = array.astype(np.int32)
+    #         ret = torch.from_numpy(array)
+    #         if ret.dtype == torch.float64:
+    #             ret = ret.float()
+    #     elif isinstance(array, torch.Tensor):
+    #         ret = array
+    #     else:
+    #         ret = torch.tensor(array)
+    #     if device is None:
+    #         if ret.device.type == "cpu":
+    #             # TODO (stao): note that .cuda does move a tensor to the torch.device context, it moves to the default
+    #             return ret.cuda()
+    #         # keep same device if already on GPU
+    #         return ret
+    #     else:
+    #         return ret.to(device)
+    # else:
+    #     if isinstance(array, np.ndarray):
+    #         if array.dtype == np.uint16:
+    #             array = array.astype(np.int32)
+    #         if array.dtype == np.uint32:
+    #             array = array.astype(np.int64)
+    #         ret = torch.from_numpy(array)
+    #         if ret.dtype == torch.float64:
+    #             ret = ret.float()
+    #     elif isinstance(array, list) and isinstance(array[0], np.ndarray):
+    #         ret = torch.from_numpy(np.array(array))
+    #         if ret.dtype == torch.float64:
+    #             ret = ret.float()
+    #     elif np.iterable(array):
+    #         ret = torch.Tensor(array)
+    #     else:
+    #         ret = torch.Tensor(array)
+    #     if device is None:
+    #         return ret
+    #     else:
+    #         return ret.to(device)
 
 
 def to_cpu_tensor(array: Array):

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -145,7 +145,7 @@ def to_tensor(array: Array, device: Optional[Device] = None):
             array = array.astype(np.int32)
         elif array.dtype == np.uint32:
             array = array.astype(np.int64)
-        ret = torch.from_numpy(array).to(device)
+        ret = torch.tensor(array).to(device)
         if ret.dtype == torch.float64:
             ret = ret.to(torch.float32)
     else:

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -10,7 +10,7 @@ import numpy as np
 import sapien.physx as physx
 import torch
 
-from mani_skill.utils.structs.types import Array, Device, get_backend_name
+from mani_skill.utils.structs.types import Array, Device
 
 # -------------------------------------------------------------------------- #
 # Utilities for working with tensors, numpy arrays, and batched data

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -214,7 +214,7 @@ def to_cpu_tensor(array: Array):
 
 # TODO (stao): Clean up this code
 def flatten_state_dict(
-    state_dict: dict, use_torch=False, device: Device = None
+    state_dict: dict, use_torch=False, device: Optional[Device] = None
 ) -> Array:
     """Flatten a dictionary containing states recursively. Expects all data to be either torch or numpy
 

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -141,7 +141,11 @@ def to_tensor(array: Array, device: Optional[Device] = None):
         ret = array.to(device)
     elif isinstance(array, np.ndarray):
         # TODO (stao): check of doing .to(device) is slow even if its just CPU
+        if array.dtype == np.uint16:
+            array = array.astype(np.int32)
         ret = torch.from_numpy(array).to(device)
+        if ret.dtype == torch.float64:
+            ret = ret.to(torch.float32)
     else:
         ret = torch.tensor(array, device=device)
     if ret.dtype == torch.float64:

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -153,46 +153,6 @@ def to_tensor(array: Array, device: Optional[Device] = None):
     if ret.dtype == torch.float64:
         ret = ret.to(torch.float32)
     return ret
-    # if physx.is_gpu_enabled():
-    #     if isinstance(array, np.ndarray):
-    #         if array.dtype == np.uint16:
-    #             array = array.astype(np.int32)
-    #         ret = torch.from_numpy(array)
-    #         if ret.dtype == torch.float64:
-    #             ret = ret.float()
-    #     elif isinstance(array, torch.Tensor):
-    #         ret = array
-    #     else:
-    #         ret = torch.tensor(array)
-    #     if device is None:
-    #         if ret.device.type == "cpu":
-    #             # TODO (stao): note that .cuda does move a tensor to the torch.device context, it moves to the default
-    #             return ret.cuda()
-    #         # keep same device if already on GPU
-    #         return ret
-    #     else:
-    #         return ret.to(device)
-    # else:
-    #     if isinstance(array, np.ndarray):
-    #         if array.dtype == np.uint16:
-    #             array = array.astype(np.int32)
-    #         if array.dtype == np.uint32:
-    #             array = array.astype(np.int64)
-    #         ret = torch.from_numpy(array)
-    #         if ret.dtype == torch.float64:
-    #             ret = ret.float()
-    #     elif isinstance(array, list) and isinstance(array[0], np.ndarray):
-    #         ret = torch.from_numpy(np.array(array))
-    #         if ret.dtype == torch.float64:
-    #             ret = ret.float()
-    #     elif np.iterable(array):
-    #         ret = torch.Tensor(array)
-    #     else:
-    #         ret = torch.Tensor(array)
-    #     if device is None:
-    #         return ret
-    #     else:
-    #         return ret.to(device)
 
 
 def to_cpu_tensor(array: Array):

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -146,12 +146,10 @@ def to_tensor(array: Array, device: Optional[Device] = None):
         elif array.dtype == np.uint32:
             array = array.astype(np.int64)
         ret = torch.tensor(array).to(device)
-        if ret.dtype == torch.float64:
-            ret = ret.to(torch.float32)
     else:
         ret = torch.tensor(array, device=device)
     if ret.dtype == torch.float64:
-        ret = ret.float()
+        ret = ret.to(torch.float32)
     return ret
     # if physx.is_gpu_enabled():
     #     if isinstance(array, np.ndarray):

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -240,20 +240,20 @@ def flatten_state_dict(
             if state.size == 0:
                 state = None
             if use_torch:
-                state = to_tensor(state)
+                state = to_tensor(state, device=device)
         elif isinstance(value, (tuple, list)):
             state = None if len(value) == 0 else value
             if use_torch:
-                state = to_tensor(state)
+                state = to_tensor(state, device=device)
         elif isinstance(value, (bool, np.bool_, int, np.int32, np.int64)):
             # x = np.array(1) > 0 is np.bool_ instead of ndarray
             state = int(value)
             if use_torch:
-                state = to_tensor(state)
+                state = to_tensor(state, device=device)
         elif isinstance(value, (float, np.float32, np.float64)):
             state = np.float32(value)
             if use_torch:
-                state = to_tensor(state)
+                state = to_tensor(state, device=device)
         elif isinstance(value, np.ndarray):
             if value.ndim > 2:
                 raise AssertionError(
@@ -261,7 +261,7 @@ def flatten_state_dict(
                 )
             state = value if value.size > 0 else None
             if use_torch:
-                state = to_tensor(state)
+                state = to_tensor(state, device=device)
 
         elif isinstance(value, torch.Tensor):
             state = value

--- a/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
+++ b/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
@@ -164,7 +164,7 @@ class AI2THORBaseSceneBuilder(SceneBuilder):
             builder.add_visual_from_file(bg_path, pose=bg_pose)
             builder.add_nonconvex_collision_from_file(bg_path, pose=bg_pose)
             builder.set_scene_idxs(env_idx)
-            bg.initial_pose = sapien.Pose()
+            builder.initial_pose = sapien.Pose()
             bg = builder.build_static(name=f"{unique_id}_scene_background")
             for i, env_num in enumerate(env_idx):
                 bgs[env_num] = bg._objs[i]

--- a/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
+++ b/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
@@ -164,6 +164,7 @@ class AI2THORBaseSceneBuilder(SceneBuilder):
             builder.add_visual_from_file(bg_path, pose=bg_pose)
             builder.add_nonconvex_collision_from_file(bg_path, pose=bg_pose)
             builder.set_scene_idxs(env_idx)
+            bg.initial_pose = sapien.Pose()
             bg = builder.build_static(name=f"{unique_id}_scene_background")
             for i, env_num in enumerate(env_idx):
                 bgs[env_num] = bg._objs[i]
@@ -207,6 +208,7 @@ class AI2THORBaseSceneBuilder(SceneBuilder):
                     builder.add_nonconvex_collision_from_file(
                         str(model_path), pose=pose
                     )
+                    builder.initial_pose = sapien.Pose()
                     builder.set_scene_idxs(env_idx)
                     actor = builder.build_static(name=f"{unique_id}_{actor_name}")
                 else:
@@ -220,10 +222,11 @@ class AI2THORBaseSceneBuilder(SceneBuilder):
                         str(model_path),
                         decomposition=convex_decomposition,
                     )
+                    pose = sapien.Pose(p=position, q=q)
+                    builder.initial_pose = pose
                     builder.set_scene_idxs(env_idx)
                     actor = builder.build(name=f"{unique_id}_{actor_name}")
 
-                    pose = sapien.Pose(p=position, q=q)
                     self._default_object_poses.append((actor, pose))
 
                     for env_num in env_idx:

--- a/mani_skill/utils/scene_builder/replicacad/rearrange/scene_builder.py
+++ b/mani_skill/utils/scene_builder/replicacad/rearrange/scene_builder.py
@@ -1,12 +1,12 @@
+import copy
+import itertools
 import json
 import os
 import os.path as osp
-from typing import Dict, List, Tuple, Optional
-from pathlib import Path
 from collections import defaultdict
-import copy
-import itertools
 from functools import cached_property
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import sapien
@@ -15,10 +15,10 @@ import torch
 import transforms3d
 
 from mani_skill import ASSET_DIR
-from mani_skill.utils.structs import Actor, Articulation
-from mani_skill.utils.building import actors
 from mani_skill.utils import common
+from mani_skill.utils.building import actors
 from mani_skill.utils.scene_builder.replicacad import ReplicaCADSceneBuilder
+from mani_skill.utils.structs import Actor, Articulation
 
 DEFAULT_HIDDEN_POS = [-10_000] * 3
 
@@ -285,7 +285,7 @@ class ReplicaCADRearrangeSceneBuilder(ReplicaCADSceneBuilder):
                         temp_p[..., 2] += 1000
                         self.show_actor(obj, sapien.Pose(q=pose.q, p=temp_p))
 
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             self.scene._gpu_apply_all()
             self.scene._gpu_fetch_all()
 
@@ -330,7 +330,7 @@ class ReplicaCADRearrangeSceneBuilder(ReplicaCADSceneBuilder):
                 articulation.set_qpos(base_qpos[reset_idxs])
                 articulation.set_qvel(articulation.qvel[reset_idxs] * 0)
 
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             self.scene._gpu_apply_all()
             self.scene.px.gpu_update_articulation_kinematics()
             self.scene.px.step()

--- a/mani_skill/utils/scene_builder/replicacad/scene_builder.py
+++ b/mani_skill/utils/scene_builder/replicacad/scene_builder.py
@@ -170,6 +170,7 @@ class ReplicaCADSceneBuilder(SceneBuilder):
                         builder.add_convex_collision_from_file(visual_file)
                     else:
                         builder.add_multiple_convex_collisions_from_file(collision_file)
+                    builder.initial_pose = pose
                     builder.set_scene_idxs(env_idx)
                     actor = builder.build(name=f"{unique_id}_{actor_name}")
                     self._default_object_poses.append((actor, pose))
@@ -220,8 +221,11 @@ class ReplicaCADSceneBuilder(SceneBuilder):
                 urdf_loader.disable_self_collisions = True
                 if "uniform_scale" in articulated_meta:
                     urdf_loader.scale = articulated_meta["uniform_scale"]
-                articulation = urdf_loader.load(urdf_path, scene_idxs=env_idx)
+                builder = urdf_loader.parse(urdf_path)["articulation_builders"][0]
                 pose = sapien.Pose(q=q) * sapien.Pose(pos, rot)
+                builder.initial_pose = pose
+                builder.set_scene_idxs(env_idx)
+                articulation = builder.build(name=articulation_name)
                 self._default_object_poses.append((articulation, pose))
 
                 # for now classify articulated objects as "movable" object

--- a/mani_skill/utils/scene_builder/replicacad/scene_builder.py
+++ b/mani_skill/utils/scene_builder/replicacad/scene_builder.py
@@ -6,10 +6,10 @@ This code is also heavily commented to serve as a tutorial for how to build cust
 
 import json
 import os.path as osp
-from pathlib import Path
 from collections import defaultdict
-from typing import Dict, List, Tuple, Union
 from functools import cached_property
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import sapien
@@ -226,12 +226,12 @@ class ReplicaCADSceneBuilder(SceneBuilder):
 
                 # for now classify articulated objects as "movable" object
                 for env_num in env_idx:
-                    self.articulations[f"env-{env_num}_{articulation_name}"] = (
-                        articulation
-                    )
-                    self.scene_objects[f"env-{env_num}_{articulation_name}"] = (
-                        articulation
-                    )
+                    self.articulations[
+                        f"env-{env_num}_{articulation_name}"
+                    ] = articulation
+                    self.scene_objects[
+                        f"env-{env_num}_{articulation_name}"
+                    ] = articulation
 
                 for link in articulation.links:
                     link.set_collision_group_bit(
@@ -289,7 +289,7 @@ class ReplicaCADSceneBuilder(SceneBuilder):
                 obj.set_qpos(obj.qpos[0] * 0)
                 obj.set_qvel(obj.qvel[0] * 0)
 
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             self.scene._gpu_apply_all()
             self.scene.px.gpu_update_articulation_kinematics()
             self.scene.px.step()

--- a/mani_skill/utils/scene_builder/replicacad/scene_builder.py
+++ b/mani_skill/utils/scene_builder/replicacad/scene_builder.py
@@ -225,7 +225,7 @@ class ReplicaCADSceneBuilder(SceneBuilder):
                 pose = sapien.Pose(q=q) * sapien.Pose(pos, rot)
                 builder.initial_pose = pose
                 builder.set_scene_idxs(env_idx)
-                articulation = builder.build(name=articulation_name)
+                articulation = builder.build()
                 self._default_object_poses.append((articulation, pose))
 
                 # for now classify articulated objects as "movable" object

--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -313,7 +313,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
 
     @property
     def pose(self) -> Pose:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             if self.px_body_type == "static":
                 # NOTE (stao): usually _builder_initial_pose is just one pose, but for static objects in GPU sim we repeat it if necessary so it can be used
                 # as part of observations if needed
@@ -339,7 +339,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
 
     @pose.setter
     def pose(self, arg1: Union[Pose, sapien.Pose, Array]) -> None:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             assert (
                 self.px_body_type != "static"
             ), "Static objects cannot change poses in GPU sim after environment is loaded"
@@ -367,7 +367,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
                 for obj in self._objs:
                     obj.pose = arg1
             else:
-                if len(arg1.shape) == 2:
+                if isinstance(arg1, Pose) and len(arg1.shape) == 2:
                     for i, obj in enumerate(self._objs):
                         obj.pose = arg1[i].sp
                 else:

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -607,7 +607,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
 
     @property
     def qpos(self):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             # NOTE (stao): cuda_articulation_qpos is of shape (M, N) where M is the total number of articulations in the physx scene,
             # N is the max dof of all those articulations.
             return self.px.cuda_articulation_qpos.torch()[
@@ -618,7 +618,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
 
     @qpos.setter
     def qpos(self, arg1: torch.Tensor):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             arg1 = common.to_tensor(arg1)
             self.px.cuda_articulation_qpos.torch()[
                 self._data_index[self.scene._reset_mask[self._scene_idxs]],
@@ -723,7 +723,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
 
         TODO (stao): can we use joint indices for the CPU sim as well? Some global joint indices?
         """
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             targets = common.to_tensor(targets)
             if joint_indices not in self._cached_joint_target_indices:
                 self._cached_joint_target_indices[joint_indices] = torch.meshgrid(
@@ -746,7 +746,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
 
         TODO (stao): can we use joint indices for the CPU sim as well? Some global joint indices?
         """
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             targets = common.to_tensor(targets)
             if joint_indices not in self._cached_joint_target_indices:
                 self._cached_joint_target_indices[joint_indices] = torch.meshgrid(

--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -131,7 +131,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
         where N is the number of environments, and 3 is the dimension of the impulse vector itself,
         representing x, y, and z direction of impulse.
         """
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             self.px.gpu_query_contact_body_impulses(self._body_force_query)
             return self._body_force_query.cuda_impulses.torch().clone()
         else:
@@ -205,7 +205,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
 
     @property
     def angular_velocity(self) -> torch.Tensor:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             # NOTE (stao): Currently physx has a bug that sapien inherits where link bodies on the GPU put linear/angular velocities in the wrong order...
             if isinstance(self._objs[0], physx.PhysxArticulationLinkComponent):
                 return self._body_data[self._body_data_index, 7:10]
@@ -225,7 +225,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
                 for x in self._bodies
             ]
         )
-        return Pose.create(common.to_tensor(raw_poses))
+        return Pose.create(common.to_tensor(raw_poses), device=self.device)
 
     # @cmass_local_pose.setter
     # def cmass_local_pose(self, arg1: sapien.pysapien.Pose) -> None:
@@ -260,7 +260,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
 
     @property
     def linear_velocity(self) -> torch.Tensor:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             # NOTE (stao): Currently physx has a bug that sapien inherits where link bodies on the GPU put linear/angular velocities in the wrong order...
             if isinstance(self._objs[0], physx.PhysxArticulationLinkComponent):
                 return self._body_data[self._body_data_index, 10:13]
@@ -275,7 +275,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
     @mass.setter
     @before_gpu_init
     def mass(self, arg1: float) -> None:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             raise NotImplementedError(
                 "Setting mass is not supported on GPU sim at the moment."
             )
@@ -345,7 +345,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
     # def wake_up(self) -> None: ...
     @property
     def angular_velocity(self) -> torch.Tensor:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             # NOTE (stao): Currently physx has a bug that sapien inherits where link bodies on the GPU put linear/angular velocities in the wrong order...
             if isinstance(self._objs[0], physx.PhysxArticulationLinkComponent):
                 return self._body_data[self._body_data_index, 7:10]
@@ -355,8 +355,8 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
 
     @angular_velocity.setter
     def angular_velocity(self, arg1: Array):
-        if physx.is_gpu_enabled():
-            arg1 = common.to_tensor(arg1)
+        if self.scene.gpu_sim_enabled:
+            arg1 = common.to_tensor(arg1, device=self.device)
             self._body_data[
                 self._body_data_index[self.scene._reset_mask[self._scene_idxs]], 10:13
             ] = arg1
@@ -368,14 +368,14 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
 
     @property
     def gpu_index(self):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             return [b.gpu_index for b in self._bodies]
         else:
             raise AttributeError("GPU index is not supported when gpu is not enabled")
 
     @property
     def gpu_pose_index(self):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             return [b.gpu_pose_index for b in self._bodies]
         else:
             raise AttributeError(
@@ -385,7 +385,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
     @property
     @before_gpu_init
     def is_sleeping(self):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             return [b.is_sleeping for b in self._bodies]
         else:
             return [self._bodies[0].is_sleeping]
@@ -427,7 +427,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
     @linear_velocity.setter
     def linear_velocity(self, arg1: Array):
         if self.scene.gpu_sim_enabled:
-            arg1 = common.to_tensor(arg1)
+            arg1 = common.to_tensor(arg1, device=self.device)
             self._body_data[
                 self._body_data_index[self.scene._reset_mask[self._scene_idxs]], 7:10
             ] = arg1

--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -416,7 +416,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
     #     pass
     @property
     def linear_velocity(self) -> torch.Tensor:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             # NOTE (stao): Currently physx has a bug that sapien inherits where link bodies on the GPU put linear/angular velocities in the wrong order...
             if isinstance(self._objs[0], physx.PhysxArticulationLinkComponent):
                 return self._body_data[self._body_data_index, 10:13]
@@ -426,7 +426,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
 
     @linear_velocity.setter
     def linear_velocity(self, arg1: Array):
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             arg1 = common.to_tensor(arg1)
             self._body_data[
                 self._body_data_index[self.scene._reset_mask[self._scene_idxs]], 7:10

--- a/mani_skill/utils/structs/link.py
+++ b/mani_skill/utils/structs/link.py
@@ -206,7 +206,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
     # -------------------------------------------------------------------------- #
     @property
     def pose(self) -> Pose:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             raw_pose = self.px.cuda_rigid_body_data.torch()[self._body_data_index, :7]
             if self.scene.parallel_in_single_scene:
                 new_xyzs = raw_pose[:, :3] - self.scene.scene_offsets[self._scene_idxs]
@@ -220,7 +220,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
 
     @pose.setter
     def pose(self, arg1: Union[Pose, sapien.Pose, Array]) -> None:
-        if physx.is_gpu_enabled():
+        if self.scene.gpu_sim_enabled:
             if not isinstance(arg1, torch.Tensor):
                 arg1 = vectorize_pose(arg1, device=self.device)
             if self.scene.parallel_in_single_scene:
@@ -242,7 +242,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
                 for obj in self._objs:
                     obj.pose = arg1
             else:
-                if len(arg1.shape) == 2:
+                if isinstance(arg1, Pose) and len(arg1.shape) == 2:
                     for i, obj in enumerate(self._objs):
                         obj.pose = arg1[i].sp
                 else:

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -189,7 +189,7 @@ class Pose:
         Multiply two poses. Supports multiplying singular poses like sapien.Pose or Pose object with batch size of 1 with Pose objects with batch size > 1.
         """
         # NOTE (stao): this code is probably slower than SAPIEN's pose multiplication but it is batched
-        arg0 = Pose.create(arg0)
+        arg0 = Pose.create(arg0, device=self.device)
         pose = self
         if len(arg0) == 1 and len(pose) > 1:
             # repeat arg0 to match shape of self

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -86,7 +86,10 @@ class Pose:
 
     @classmethod
     def create_from_pq(
-        cls, p: torch.Tensor = None, q: torch.Tensor = None, device: Device = None
+        cls,
+        p: Optional[torch.Tensor] = None,
+        q: Optional[torch.Tensor] = None,
+        device: Optional[Device] = None,
     ):
         """Creates a Pose object from a given position ``p`` and/or quaternion ``q``"""
         if p is None:
@@ -135,7 +138,7 @@ class Pose:
 
         else:
             assert len(pose.shape) <= 2 and len(pose.shape) > 0
-            pose = common.to_tensor(pose)
+            pose = common.to_tensor(pose, device=device)
             pose = add_batch_dim(pose)
             if pose.shape[-1] == 3:
                 return cls.create_from_pq(p=pose, device=pose.device)

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -122,7 +122,7 @@ class Pose:
             )
             return cls(raw_pose=add_batch_dim(raw_pose))
         elif isinstance(pose, cls):
-            return pose
+            return pose.to(device)
         elif isinstance(pose, list) and isinstance(pose[0], sapien.Pose):
             ps = []
             qs = []
@@ -267,17 +267,14 @@ def vectorize_pose(
     Maps several formats of Pose representation to the appropriate tensor representation
     """
     if isinstance(pose, sapien.Pose):
-        if physx.is_gpu_enabled():
-            return torch.concatenate(
-                [
-                    common.to_tensor(pose.p, device=device),
-                    common.to_tensor(pose.q, device=device),
-                ]
-            )
-        else:
-            return np.hstack([pose.p, pose.q])
+        return torch.concatenate(
+            [
+                common.to_tensor(pose.p, device=device),
+                common.to_tensor(pose.q, device=device),
+            ]
+        )
     elif isinstance(pose, Pose):
-        return pose.raw_pose
+        return pose.raw_pose.to(device)
     else:
         return common.to_tensor(pose, device=device)
 

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -92,6 +92,15 @@ class Pose:
         device: Optional[Device] = None,
     ):
         """Creates a Pose object from a given position ``p`` and/or quaternion ``q``"""
+        if device is None:
+            # try to guess which device to use
+            device = (
+                p.device
+                if p is not None and isinstance(p, torch.Tensor)
+                else q.device
+                if q is not None and isinstance(q, torch.Tensor)
+                else None
+            )
         if p is None:
             p = torch.zeros((1, 3), device=device)
         if q is None:

--- a/mani_skill/utils/structs/pose.py
+++ b/mani_skill/utils/structs/pose.py
@@ -21,10 +21,10 @@ def add_batch_dim(x):
     return x
 
 
-def to_batched_tensor(x: Union[List, Array]):
+def to_batched_tensor(x: Union[List, Array], device: Optional[Device] = None):
     if x is None:
         return None
-    return add_batch_dim(common.to_tensor(x))
+    return add_batch_dim(common.to_tensor(x, device=device))
 
 
 @dataclass
@@ -106,7 +106,7 @@ class Pose:
         if q is None:
             q = torch.zeros((1, 4), device=device)
             q[:, 0] = 1
-        p, q = to_batched_tensor(p), to_batched_tensor(q)
+        p, q = to_batched_tensor(p, device=device), to_batched_tensor(q, device=device)
 
         # correct batch sizes if needed
         if p.shape[0] > q.shape[0]:

--- a/mani_skill/utils/structs/types.py
+++ b/mani_skill/utils/structs/types.py
@@ -5,14 +5,6 @@ import numpy as np
 import sapien.physx as physx
 import torch
 
-
-def get_backend_name():
-    if physx.is_gpu_enabled():
-        return "torch"
-    else:
-        return "numpy"
-
-
 Array = Union[torch.Tensor, np.ndarray, Sequence]
 Device = Union[str, torch.device]
 

--- a/mani_skill/utils/wrappers/gymnasium.py
+++ b/mani_skill/utils/wrappers/gymnasium.py
@@ -36,7 +36,7 @@ class CPUGymWrapper(gym.Wrapper):
             self.base_env.num_envs == 1
         ), "This wrapper is only for environments without parallelization"
         assert (
-            not physx.is_gpu_enabled()
+            not self.base_env.gpu_sim_enabled
         ), "This wrapper is only for environments on the CPU backend"
         self.observation_space = self.base_env.single_observation_space
         self.action_space = self.base_env.single_action_space


### PR DESCRIPTION
this should allow one to run a CPU sim and GPU sim in the same process more easily, which can then start to support a workflow with multiprocessing CPU sim and then dumping state to the GPU sim for rendering