### PR TITLE
[Feature] Unified states for heterogenous simulated envs

### DIFF
--- a/docs/source/user_guide/tutorials/custom_tasks/advanced.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/advanced.md
@@ -2,27 +2,6 @@
 
 This page covers nearly every feature useful for task building in ManiSkill. If you haven't already it is recommended to get a better understanding of how GPU simulation generally works described on [this page](../../concepts/gpu_simulation.md). It can provide some good context for various terminology and ideas presented in this advanced features tutorial.
 
-## Custom/Extra State
-
-Reproducibility is generally important in task building. A common example is when trying to replay a trajectory that someone else generated, if that trajectory file is missing important state variables necessary for reconstructing the exact same initial task state, the trajectory likely would not replay correctly.
-
-By default, `env.get_state_dict()` returns a state dictionary containing the entirety of simulation state, which consists of the poses and velocities of each actor and additionally qpos/qvel values of articulations.
-
-In your own task you can define additional state data such as a eg `height` for a task like LiftCube which indicates how high the cube must be lifted for success. This would be your own variable and not included in `env.get_state_dict()` so to include it you can add the following two functions to your task class
-
-```python
-class MyCustomTask(BaseEnv):
-    # ...
-    def get_state_dict(self):
-        state_dict = super().get_state_dict()
-        state_dict["height"] = self.height
-    def set_state_dict(self, state_dict):
-        super().set_state_dict(state_dict)
-        self.height = state_dict["height"]
-```
-
-Now recorded trajectories of your task will include the height as part of the environment state and so you can replay the trajectory with just environment states perfectly in the sense that the robot path is the same and the evaluation/reward metrics output the same at each time step.
-
 ## Contact Forces on the GPU/CPU
 
 ### Pair-wise Contact Forces
@@ -138,6 +117,54 @@ class MyCustomTask(BaseEnv):
         link.joint # a merged joint object
         link.joint.qpos # shape (N, 1)
         link.joint.qvel # shape (N, 1)
+```
+
+
+## Custom/Extra State
+
+Reproducibility is generally important in task building. A common example is when trying to replay a trajectory that someone else generated, if that trajectory file is missing important state variables necessary for reconstructing the exact same initial task state, the trajectory likely would not replay correctly.
+
+By default, `env.get_state_dict()` returns a state dictionary containing the entirety of simulation state of actors and articulations in the state dict registry. Actor state is a flat `13` dimensional composed of 3D position, 4D quaternion, 3D linear velocity, and 3D angular velocity. Articulation state is a flat `13 + 2 * DOF` dimensional vector, with 13 dimensions corresponding to the root link's pose and velocities like actors, and the next `DOF` dimensions corresponding to the active joint positions and the last `DOF` dimensions corresponding to the active joint velocities.
+
+By default, anytime an actor or articulation is built, it is automatically added to the state dict registry which can be viewed via `env.scene.state_dict_registry`.
+
+### Handling Custom States
+
+In your own task you can define additional state data such as a eg `height` for a task like LiftCube which indicates how high the cube must be lifted for success. This would be your own variable and not included in `env.get_state_dict()` so to include it you can add the following two functions to your task class
+
+```python
+class MyCustomTask(BaseEnv):
+    # ...
+    def get_state_dict(self):
+        state_dict = super().get_state_dict()
+        state_dict["height"] = self.height
+    def set_state_dict(self, state_dict):
+        super().set_state_dict(state_dict)
+        self.height = state_dict["height"]
+```
+
+Now recorded trajectories of your task will include the height as part of the environment state and so you can replay the trajectory with just environment states perfectly in the sense that the robot path is the same and the evaluation/reward metrics output the same at each time step.
+
+### Handling Heterogeneous Simulation States
+
+Many tasks like OpenCabinetDrawer-v1 and PegInsertionSide-v1 support heterogeneous simulation where each environment has a different object/geometry/dof. For these tasks often times during scene loading you run a for loop to create each different object in each parallel environment. However in doing so you have to give them each a different name which causes inconsistenency in the environment state as now the number of environments changes the shape of the state dictionary. To handle this you need to remove the per-environment actor/articulation from the state dictionary registry and add in the merged version. See sections on how to use [scene masks](#scene-masks) and [merging](#merging) for information on how to build heterogeneous simulated environments.
+
+```python
+class MyCustomTask(BaseEnv):
+    # ...
+    def _load_scene(options):
+        # ... 
+        for i in range(self.num_envs):
+            # build your object ...
+            name = f"object_{i}"
+            object_i = builder.build(name=name)
+            self.remove_from_state_dict_registry(object_i)
+
+        self.object = Actor.merge(objects, name="object") 
+        # or if its articulation you use Articulation.merge
+        self.register_to_state_dict_registry(self.object)
+        # note that some tasks merge links, but links do not need to be registered to the state dict registry, they are
+        # automatically included with merged articulations
 ```
 
 

--- a/docs/source/user_guide/tutorials/custom_tasks/intro.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/intro.md
@@ -72,7 +72,7 @@ class PushCubeEnv(BaseEnv):
     def _load_agent(self, options: dict):
         super()._load_agent(options, sapien.Pose(p=[0, 0, 1]))
 ```
-To define the initial pose of the robot you ovverride the `_load_agent` function. This is done in PushCube above. It is recommended to set initial poses for all objects such that if they were spawned there they don't intersect other objects. Here we spawn the robot 1 meter above the ground which won't clash with anything else.
+To define the initial pose of the robot you ovverride the `_load_agent` function. This is done in PushCube above. It is recommended to set initial poses for all objects such that if they were spawned there they don't intersect other objects. Here we spawn the robot 1 meter above the ground which won't clash with anything else. If you are intending to spawn multiple robots you can pass a list of poses to the `_load_agent` function.
 
 
 Initializing/randomizing these robots occurs in the initialization / randomization section covered later. With this setup you can later access agent data via `self.agent` and the specific articulation data of the robot via `self.agent.robot`. For multi-robot setups you can access each agent via `self.agent.agents`.

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1132,6 +1132,11 @@ class BaseEnv(gym.Env):
                 res[link._objs[0].entity.per_scene_id] = link
         return res
 
+    def add_to_state_dict_registry(self, object: Union[Actor, Articulation]):
+        self.scene.add_to_state_dict_registry(object)
+    def remove_from_state_dict_registry(self, object: Union[Actor, Articulation]):
+        self.scene.remove_from_state_dict_registry(object)
+
     def get_state_dict(self):
         """
         Get environment state dictionary. Override to include task information (e.g., goal)

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -890,12 +890,12 @@ class BaseEnv(gym.Env):
     def _set_episode_rng(self, seed: Union[None, list[int]], env_idx: torch.Tensor):
         """Set the random generator for current episode."""
         if seed is not None or self._enhanced_determinism:
-            if not np.iterable(seed):
-                seed = [seed]
             env_idx = common.to_numpy(env_idx)
             if seed is None:
                 self._episode_seed[env_idx] = self._batched_main_rng[env_idx].randint(2**31)
             else:
+                if not np.iterable(seed):
+                    seed = [seed]
                 self._episode_seed = common.to_numpy(seed, dtype=np.int64)
                 if len(self._episode_seed) == 1 and self.num_envs > 1:
                     self._episode_seed = np.concatenate((self._episode_seed, np.random.RandomState(self._episode_seed[0]).randint(2**31, size=(self.num_envs - 1,))))

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -813,11 +813,11 @@ class ManiSkillScene:
         state_dict = dict()
         state_dict["actors"] = dict()
         state_dict["articulations"] = dict()
-        for actor in self.actors.values():
+        for actor in self.state_dict_registry.actors.values():
             if actor.px_body_type == "static":
                 continue
             state_dict["actors"][actor.name] = actor.get_state().clone()
-        for articulation in self.articulations.values():
+        for articulation in self.state_dict_registry.articulations.values():
             state_dict["articulations"][
                 articulation.name
             ] = articulation.get_state().clone()

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -26,6 +27,12 @@ if SAPIEN_RENDER_SYSTEM == "3.1":
 
     GlobalShaderPack = None
     sapien.render.RenderCameraGroup = "oldtype"  # type: ignore
+
+
+@dataclass
+class StateDictRegistry:
+    actors: Dict[str, Actor]
+    articulations: Dict[str, Articulation]
 
 
 class ManiSkillScene:
@@ -97,6 +104,11 @@ class ManiSkillScene:
 
         self.parallel_in_single_scene: bool = parallel_in_single_scene
         """Whether rendering all parallel scenes in the viewer/gui is enabled"""
+
+        self.state_dict_registry: StateDictRegistry = StateDictRegistry(
+            actors=dict(), articulations=dict()
+        )
+        """state dict registry that map actor/articulation names to Actor/Articulation struct references. Only these structs are used for the environment state"""
 
     # -------------------------------------------------------------------------- #
     # Functions from sapien.Scene
@@ -762,6 +774,35 @@ class ManiSkillScene:
     # -------------------------------------------------------------------------- #
     # Simulation state (required for MPC)
     # -------------------------------------------------------------------------- #
+
+    def add_to_state_dict_registry(self, object: Union[Actor, Articulation]):
+        if isinstance(object, Actor):
+            assert (
+                object.name not in self.state_dict_registry.actors
+            ), f"Object {object.name} already in state dict registry"
+            self.state_dict_registry.actors[object.name] = object
+        elif isinstance(object, Articulation):
+            assert (
+                object.name not in self.state_dict_registry.articulations
+            ), f"Object {object.name} already in state dict registry"
+            self.state_dict_registry.articulations[object.name] = object
+        else:
+            raise ValueError(f"Expected Actor or Articulation, got {object}")
+
+    def remove_from_state_dict_registry(self, object: Union[Actor, Articulation]):
+        if isinstance(object, Actor):
+            assert (
+                object.name in self.state_dict_registry.actors
+            ), f"Object {object.name} not in state dict registry"
+            del self.state_dict_registry.actors[object.name]
+        elif isinstance(object, Articulation):
+            assert (
+                object.name in self.state_dict_registry.articulations
+            ), f"Object {object.name} not in state dict registry"
+            del self.state_dict_registry.articulations[object.name]
+        else:
+            raise ValueError(f"Expected Actor or Articulation, got {object}")
+
     def get_sim_state(self) -> torch.Tensor:
         """Get simulation state. Returns a dictionary with two nested dictionaries "actors" and "articulations".
         In the nested dictionaries they map the actor/articulation name to a vector of shape (N, D) for N parallel

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -839,12 +839,14 @@ class ManiSkillScene:
                 if len(actor_state.shape) == 1:
                     actor_state = actor_state[None, :]
                 # do not pass in env_idx to avoid redundant reset mask changes
-                self.actors[actor_id].set_state(actor_state, None)
+                self.state_dict_registry.actors[actor_id].set_state(actor_state, None)
         if "articulations" in state:
             for art_id, art_state in state["articulations"].items():
                 if len(art_state.shape) == 1:
                     art_state = art_state[None, :]
-                self.articulations[art_id].set_state(art_state, None)
+                self.state_dict_registry.articulations[art_id].set_state(
+                    art_state, None
+                )
         if env_idx is not None:
             self._reset_mask = prev_reset_mask
 

--- a/mani_skill/envs/tasks/digital_twins/bridge_dataset_eval/base_env.py
+++ b/mani_skill/envs/tasks/digital_twins/bridge_dataset_eval/base_env.py
@@ -158,7 +158,6 @@ class BaseBridgeEnv(BaseDigitalTwinEnv):
     SUPPORTED_OBS_MODES = ["rgb+segmentation"]
     SUPPORTED_REWARD_MODES = ["none"]
     scene_setting: Literal["flat_table", "sink"] = "flat_table"
-    objs: Dict[str, Actor] = dict()
 
     obj_static_friction = 0.5
     obj_dynamic_friction = 0.5
@@ -170,6 +169,7 @@ class BaseBridgeEnv(BaseDigitalTwinEnv):
         quat_configs: torch.Tensor,
         **kwargs,
     ):
+        self.objs: Dict[str, Actor] = dict()
         self.obj_names = obj_names
         self.source_obj_name = obj_names[0]
         self.target_obj_name = obj_names[1]

--- a/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
+++ b/mani_skill/envs/tasks/mobile_manipulation/open_cabinet_drawer.py
@@ -126,7 +126,7 @@ class OpenCabinetDrawerEnv(BaseEnv):
             cabinet_builder.set_scene_idxs(scene_idxs=[i])
             cabinet_builder.initial_pose = sapien.Pose(p=[0, 0, 0], q=[1, 0, 0, 0])
             cabinet = cabinet_builder.build(name=f"{model_id}-{i}")
-
+            self.remove_from_state_dict_registry(cabinet)
             # this disables self collisions by setting the group 2 bit at CABINET_COLLISION_BIT all the same
             # that bit is also used to disable collision with the ground plane
             for link in cabinet.links:
@@ -156,6 +156,7 @@ class OpenCabinetDrawerEnv(BaseEnv):
         # allowing you to manage all of them under one object and retrieve data like qpos, pose, etc. all together
         # and with high performance. Note that some properties such as qpos and qlimits are now padded.
         self.cabinet = Articulation.merge(self._cabinets, name="cabinet")
+        self.add_to_state_dict_registry(self.cabinet)
         self.handle_link = Link.merge(
             [links[link_ids[i] % len(links)] for i, links in enumerate(handle_links)],
             name="handle_link",

--- a/mani_skill/envs/tasks/tabletop/peg_insertion_side.py
+++ b/mani_skill/envs/tasks/tabletop/peg_insertion_side.py
@@ -151,7 +151,7 @@ class PegInsertionSideEnv(BaseEnv):
                 builder.initial_pose = sapien.Pose(p=[0, 0, 0.1])
                 builder.set_scene_idxs(scene_idxs)
                 peg = builder.build(f"peg_{i}")
-
+                self.remove_from_state_dict_registry(peg)
                 # box with hole
 
                 inner_radius, outer_radius, depth = (
@@ -165,11 +165,16 @@ class PegInsertionSideEnv(BaseEnv):
                 builder.initial_pose = sapien.Pose(p=[0, 1, 0.1])
                 builder.set_scene_idxs(scene_idxs)
                 box = builder.build_kinematic(f"box_with_hole_{i}")
-
+                self.remove_from_state_dict_registry(box)
                 pegs.append(peg)
                 boxes.append(box)
             self.peg = Actor.merge(pegs, "peg")
             self.box = Actor.merge(boxes, "box_with_hole")
+
+            # to support heterogeneous simulation state dictionaries we register merged versions
+            # of the parallel actors
+            self.add_to_state_dict_registry(self.peg)
+            self.add_to_state_dict_registry(self.box)
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: dict):
         with torch.device(self.device):

--- a/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
+++ b/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
@@ -93,7 +93,7 @@ class PickSingleYCBEnv(BaseEnv):
             print(
                 """There are less parallel environments than total available models to sample.
                 Not all models will be used during interaction even after resets unless you call env.reset(options=dict(reconfigure=True))
-                or set reconfiguration_freq to be > 1."""
+                or set reconfiguration_freq to be >= 1."""
             )
 
         self._objs: List[Actor] = []

--- a/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
+++ b/mani_skill/envs/tasks/tabletop/pick_single_ycb.py
@@ -107,7 +107,9 @@ class PickSingleYCBEnv(BaseEnv):
             builder.initial_pose = sapien.Pose(p=[0, 0, 0])
             builder.set_scene_idxs([i])
             self._objs.append(builder.build(name=f"{model_id}-{i}"))
+            self.remove_from_state_dict_registry(self._objs[-1])
         self.obj = Actor.merge(self._objs, name="ycb_object")
+        self.add_to_state_dict_registry(self.obj)
 
         self.goal_site = actors.build_sphere(
             self.scene,
@@ -135,7 +137,6 @@ class PickSingleYCBEnv(BaseEnv):
             xyz = torch.zeros((b, 3))
             xyz[:, :2] = torch.rand((b, 2)) * 0.2 - 0.1
             xyz[:, 2] = self.object_zs[env_idx]
-            print(xyz)
             qs = random_quaternions(b, lock_x=True, lock_y=True)
             self.obj.set_pose(Pose.create_from_pq(p=xyz, q=qs))
 

--- a/mani_skill/envs/tasks/tabletop/turn_faucet.py
+++ b/mani_skill/envs/tasks/tabletop/turn_faucet.py
@@ -96,6 +96,7 @@ class TurnFaucetEnv(BaseEnv):
             builder.set_scene_idxs(scene_idxs=[i])
             builder.initial_pose = sapien.Pose(p=[0, 0, model_info["offset"][2]])
             faucet = builder.build(name=f"{model_id}-{i}")
+            self.remove_task_actors(faucet)
             for joint in faucet.active_joints:
                 joint.set_friction(1.0)
                 joint.set_drive_properties(0, 10.0)
@@ -120,6 +121,7 @@ class TurnFaucetEnv(BaseEnv):
             )
 
         self.faucet = Articulation.merge(self._faucets, name="faucet")
+        self.add_task_actors(self.faucet)
         self.target_switch_link = Link.merge(self._target_switch_links, name="switch")
         self.model_offsets = common.to_tensor(self.model_offsets, device=self.device)
         self.model_offsets[:, 2] += 0.01  # small clearance

--- a/mani_skill/envs/tasks/tabletop/turn_faucet.py
+++ b/mani_skill/envs/tasks/tabletop/turn_faucet.py
@@ -96,7 +96,7 @@ class TurnFaucetEnv(BaseEnv):
             builder.set_scene_idxs(scene_idxs=[i])
             builder.initial_pose = sapien.Pose(p=[0, 0, model_info["offset"][2]])
             faucet = builder.build(name=f"{model_id}-{i}")
-            self.remove_task_actors(faucet)
+            self.remove_from_state_dict_registry(faucet)
             for joint in faucet.active_joints:
                 joint.set_friction(1.0)
                 joint.set_drive_properties(0, 10.0)
@@ -121,7 +121,7 @@ class TurnFaucetEnv(BaseEnv):
             )
 
         self.faucet = Articulation.merge(self._faucets, name="faucet")
-        self.add_task_actors(self.faucet)
+        self.add_to_state_dict_registry(self.faucet)
         self.target_switch_link = Link.merge(self._target_switch_links, name="switch")
         self.model_offsets = common.to_tensor(self.model_offsets, device=self.device)
         self.model_offsets[:, 2] += 0.01  # small clearance

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -3,6 +3,7 @@ import numpy as np
 import sapien
 
 from mani_skill.envs.sapien_env import BaseEnv
+from mani_skill.utils import gym_utils
 from mani_skill.utils.wrappers import RecordEpisode
 
 
@@ -86,7 +87,8 @@ def main(args: Args):
     record_dir = args.record_dir
     if record_dir:
         record_dir = record_dir.format(env_id=args.env_id)
-        env = RecordEpisode(env, record_dir, info_on_video=False, save_trajectory=False, max_steps_per_video=env._max_episode_steps)
+        import ipdb;ipdb.set_trace()
+        env = RecordEpisode(env, record_dir, info_on_video=False, save_trajectory=True, max_steps_per_video=gym_utils.find_max_episode_steps_value(env))
 
     if verbose:
         print("Observation space", env.observation_space)

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -87,7 +87,6 @@ def main(args: Args):
     record_dir = args.record_dir
     if record_dir:
         record_dir = record_dir.format(env_id=args.env_id)
-        import ipdb;ipdb.set_trace()
         env = RecordEpisode(env, record_dir, info_on_video=False, save_trajectory=True, max_steps_per_video=gym_utils.find_max_episode_steps_value(env))
 
     if verbose:

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -87,7 +87,7 @@ def main(args: Args):
     record_dir = args.record_dir
     if record_dir:
         record_dir = record_dir.format(env_id=args.env_id)
-        env = RecordEpisode(env, record_dir, info_on_video=False, save_trajectory=True, max_steps_per_video=gym_utils.find_max_episode_steps_value(env))
+        env = RecordEpisode(env, record_dir, info_on_video=False, save_trajectory=False, max_steps_per_video=gym_utils.find_max_episode_steps_value(env))
 
     if verbose:
         print("Observation space", env.observation_space)

--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -76,6 +76,9 @@ class Args:
     render_mode: str = "rgb_array"
     """The render mode used for saving videos. Typically there is also 'sensors' and 'all' render modes which further render all sensor outputs like cameras."""
 
+    num_envs: Optional[int] = None
+    """Number of environments to run to replay trajectories # TODO ELABORATE."""
+
 
 def parse_args(args=None):
     return tyro.cli(Args, args=args)
@@ -114,23 +117,23 @@ def _main(args, proc_id: int = 0, num_procs=1, pbar=None):
         env_kwargs["control_mode"] = target_control_mode
     env_kwargs["shader_dir"] = args.shader
     env_kwargs["reward_mode"] = args.reward_mode
-    env_kwargs["render_mode"] = (
+    env_kwargs[
+        "render_mode"
+    ] = (
         args.render_mode
     )  # note this only affects the videos saved as RecordEpisode wrapper calls env.render
 
     # handle warnings/errors for replaying trajectories generated during GPU simulation
+    if args.num_envs is not None:
+        env_kwargs["num_envs"] = args.num_envs
     if "num_envs" in env_kwargs:
         if env_kwargs["num_envs"] > 1:
             raise RuntimeError(
-                """Cannot replay trajectories that were generated in a GPU
-            simulation with more than one environment. To replay trajectories generated during GPU simulation,
-            make sure to set num_envs=1 and sim_backend="gpu" in the env kwargs."""
+                """Currently cannot replay trajectories in parallelized environments with num_envs > 1.
+                Either num_envs>1 in the CLI args or the trajectory data itself was created with num_envs>1.
+                Please set --num-envs=1
+                """
             )
-        if "sim_backend" in env_kwargs:
-            # if sim backend is "gpu", we change it to CPU if ray tracing shader is used as RT is not supported yet on GPU sim backends
-            # TODO (stao): remove this if we ever support RT on GPU sim.
-            if args.shader[:2] == "rt":
-                env_kwargs["sim_backend"] = "cpu"
 
     if args.sim_backend:
         env_kwargs["sim_backend"] = args.sim_backend

--- a/mani_skill/utils/building/actor_builder.py
+++ b/mani_skill/utils/building/actor_builder.py
@@ -259,6 +259,7 @@ class ActorBuilder(SAPIENActorBuilder):
         else:
             actor.initial_pose = self.initial_pose
         self.scene.actors[self.name] = actor
+        self.scene.add_to_state_dict_registry(actor)
         return actor
 
     """

--- a/mani_skill/utils/building/articulation_builder.py
+++ b/mani_skill/utils/building/articulation_builder.py
@@ -211,4 +211,5 @@ class ArticulationBuilder(SapienArticulationBuilder):
         )
         articulation.initial_pose = self.initial_pose
         self.scene.articulations[self.name] = articulation
+        self.scene.add_to_state_dict_registry(articulation)
         return articulation

--- a/mani_skill/utils/gym_utils.py
+++ b/mani_skill/utils/gym_utils.py
@@ -27,10 +27,14 @@ def find_max_episode_steps_value(env):
     elif isinstance(cur, ManiSkillVectorEnv):
         cur = env._env
     while cur is not None:
-        if hasattr(cur, "max_episode_steps"):
-            return cur.max_episode_steps
-        if hasattr(cur, "_max_episode_steps"):
-            return cur._max_episode_steps
+        try:
+            return cur.get_wrapper_attr("max_episode_steps")
+        except AttributeError:
+            pass
+        try:
+            return cur.get_wrapper_attr("_max_episode_steps")
+        except AttributeError:
+            pass
         if cur.spec is not None and cur.spec.max_episode_steps is not None:
             return cur.spec.max_episode_steps
         if hasattr(cur, "env"):

--- a/mani_skill/utils/sapien_utils.py
+++ b/mani_skill/utils/sapien_utils.py
@@ -405,3 +405,16 @@ def check_actor_static(actor: Actor, lin_thresh=1e-3, ang_thresh=1e-2):
         torch.linalg.norm(actor.linear_velocity, axis=1) <= lin_thresh,
         torch.linalg.norm(actor.angular_velocity, axis=1) <= ang_thresh,
     )
+
+
+def is_state_dict_consistent(state_dict: dict):
+    """Checks if the given state dictionary (generated via env.get_state_dict()) is consistent where each actor/articulation has the same batch dimension"""
+    batch_size = None
+    for name in ["actors", "articulations"]:
+        for k, v in state_dict[name].items():
+            if batch_size is None:
+                batch_size = v.shape[0]
+            else:
+                if v.shape[0] != batch_size:
+                    return False
+    return True

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -141,7 +141,9 @@ def test_env_seeded_reset():
 
 def test_env_seeded_sequence_reset():
     N = 17
-    env = gym.make(STATIONARY_ENV_IDS[0], max_episode_steps=5)
+    env = gym.make(
+        STATIONARY_ENV_IDS[0], max_episode_steps=5, enhanced_determinism=True
+    )
     obs, _ = env.reset(seed=2000)
     actions = [env.action_space.sample() for _ in range(N)]
     for i in range(N):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -20,7 +20,7 @@ from tests.utils import (
 
 @pytest.mark.parametrize("env_id", ENV_IDS)
 def test_all_envs(env_id):
-    env = gym.make(env_id, obs_mode="state")
+    env = gym.make(env_id)
     obs, _ = env.reset()
     action_space = env.action_space
     for _ in range(5):

--- a/tests/test_gpu_envs.py
+++ b/tests/test_gpu_envs.py
@@ -194,36 +194,6 @@ def test_env_reconfiguration(env_id):
 
 
 @pytest.mark.gpu_sim
-def test_raw_sim_states():
-    # Test sim state get and set works for environment without overriden get_state_dict functions
-    env = gym.make(
-        "PickCube-v1", num_envs=16, obs_mode="state_dict", sim_config=LOW_MEM_SIM_CONFIG
-    )
-    base_env: BaseEnv = env.unwrapped
-    obs1, _ = env.reset()
-    state_dict = base_env.get_state_dict()
-    assert isinstance(state_dict, dict)
-    assert state_dict["actors"]["cube"].shape == (16, 13)
-    assert state_dict["actors"]["goal_site"].shape == (16, 13)
-    assert state_dict["articulations"]["panda"].shape == (16, 13 + 9 * 2)
-    for i in range(5):
-        env.step(env.action_space.sample())
-    base_env.set_state_dict(state_dict)
-    set_obs = base_env.get_obs()
-    assert_obs_equal(obs1, set_obs)
-    for i in range(5):
-        env.step(env.action_space.sample())
-    state = base_env.get_state()
-    obs1 = base_env.get_obs()
-    assert state.shape == (16, 13 * 3 + 13 + 9 * 2)
-    for i in range(5):
-        env.step(env.action_space.sample())
-    base_env.set_state(state)
-    set_obs = base_env.get_obs()
-    assert_obs_equal(obs1, set_obs)
-
-
-@pytest.mark.gpu_sim
 @pytest.mark.parametrize("env_id", STATIONARY_ENV_IDS)
 @pytest.mark.parametrize("robot_uids", SINGLE_ARM_STATIONARY_ROBOTS)
 def test_robots(env_id, robot_uids):

--- a/tests/test_gpu_envs.py
+++ b/tests/test_gpu_envs.py
@@ -27,7 +27,7 @@ def test_all_envs(env_id):
     sim_config = dict()
     if "Scene" not in env_id:
         sim_config = LOW_MEM_SIM_CONFIG
-    env = gym.make(env_id, num_envs=16, obs_mode="state", sim_config=sim_config)
+    env = gym.make(env_id, num_envs=16, sim_config=sim_config)
     obs, _ = env.reset()
     action_space = env.action_space
     for _ in range(5):

--- a/tests/test_sim_state.py
+++ b/tests/test_sim_state.py
@@ -38,7 +38,7 @@ def test_raw_sim_states():
 
 
 @pytest.mark.gpu_sim
-def test_raw_heterogeneous_sim_states():
+def test_raw_heterogeneous_actor_sim_states():
     # Test sim state get and set works for environment without overriden get_state_dict functions
     env = gym.make(
         "PegInsertionSide-v1",
@@ -50,9 +50,9 @@ def test_raw_heterogeneous_sim_states():
     obs1, _ = env.reset()
     state_dict = base_env.get_state_dict()
     assert isinstance(state_dict, dict)
-    assert state_dict["actors"]["cube"].shape == (16, 13)
-    assert state_dict["actors"]["goal_site"].shape == (16, 13)
-    assert state_dict["articulations"]["panda"].shape == (16, 13 + 9 * 2)
+    assert state_dict["actors"]["peg"].shape == (16, 13)
+    assert state_dict["actors"]["box_with_hole"].shape == (16, 13)
+    assert state_dict["articulations"]["panda_wristcam"].shape == (16, 13 + 9 * 2)
     for i in range(5):
         env.step(env.action_space.sample())
     base_env.set_state_dict(state_dict)
@@ -63,6 +63,39 @@ def test_raw_heterogeneous_sim_states():
     state = base_env.get_state()
     obs1 = base_env.get_obs()
     assert state.shape == (16, 13 * 3 + 13 + 9 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state(state)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)
+
+
+@pytest.mark.gpu_sim
+def test_raw_heterogeneous_articulations_sim_states():
+    # Test sim state get and set works for environment without overriden get_state_dict functions
+    env = gym.make(
+        "OpenCabinetDrawer-v1",
+        num_envs=16,
+        obs_mode="state_dict",
+        sim_config=LOW_MEM_SIM_CONFIG,
+    )
+    base_env: BaseEnv = env.unwrapped
+    obs1, _ = env.reset()
+    state_dict = base_env.get_state_dict()
+    assert isinstance(state_dict, dict)
+    max_dof = base_env.cabinet.max_dof
+    assert state_dict["articulations"]["cabinet"].shape == (16, 13 + max_dof * 2)
+    assert state_dict["articulations"]["fetch"].shape == (16, 13 + 15 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state_dict(state_dict)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    state = base_env.get_state()
+    obs1 = base_env.get_obs()
+    assert state.shape == (16, 13 + 13 + max_dof * 2 + 13 + 15 * 2)
     for i in range(5):
         env.step(env.action_space.sample())
     base_env.set_state(state)

--- a/tests/test_sim_state.py
+++ b/tests/test_sim_state.py
@@ -1,0 +1,70 @@
+import gymnasium as gym
+import numpy as np
+import pytest
+import torch
+
+from mani_skill.envs.sapien_env import BaseEnv
+from tests.utils import LOW_MEM_SIM_CONFIG, assert_obs_equal
+
+
+@pytest.mark.gpu_sim
+def test_raw_sim_states():
+    # Test sim state get and set works for environment without overriden get_state_dict functions
+    env = gym.make(
+        "PickCube-v1", num_envs=16, obs_mode="state_dict", sim_config=LOW_MEM_SIM_CONFIG
+    )
+    base_env: BaseEnv = env.unwrapped
+    obs1, _ = env.reset()
+    state_dict = base_env.get_state_dict()
+    assert isinstance(state_dict, dict)
+    assert state_dict["actors"]["cube"].shape == (16, 13)
+    assert state_dict["actors"]["goal_site"].shape == (16, 13)
+    assert state_dict["articulations"]["panda"].shape == (16, 13 + 9 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state_dict(state_dict)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    state = base_env.get_state()
+    obs1 = base_env.get_obs()
+    assert state.shape == (16, 13 * 3 + 13 + 9 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state(state)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)
+
+
+@pytest.mark.gpu_sim
+def test_raw_heterogeneous_sim_states():
+    # Test sim state get and set works for environment without overriden get_state_dict functions
+    env = gym.make(
+        "PegInsertionSide-v1",
+        num_envs=16,
+        obs_mode="state_dict",
+        sim_config=LOW_MEM_SIM_CONFIG,
+    )
+    base_env: BaseEnv = env.unwrapped
+    obs1, _ = env.reset()
+    state_dict = base_env.get_state_dict()
+    assert isinstance(state_dict, dict)
+    assert state_dict["actors"]["cube"].shape == (16, 13)
+    assert state_dict["actors"]["goal_site"].shape == (16, 13)
+    assert state_dict["articulations"]["panda"].shape == (16, 13 + 9 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state_dict(state_dict)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    state = base_env.get_state()
+    obs1 = base_env.get_obs()
+    assert state.shape == (16, 13 * 3 + 13 + 9 * 2)
+    for i in range(5):
+        env.step(env.action_space.sample())
+    base_env.set_state(state)
+    set_obs = base_env.get_obs()
+    assert_obs_equal(obs1, set_obs)


### PR DESCRIPTION
- New state dict registry concept. All actors/articulations are automatically added and get_state_dict searches this registry instead of its internally maintained dict of actors/articulations.
- User can manually remove and add to this registry. For heterogeneous sims where you often have a different name for each different actor you build, you can remove the individual actors and add in the merged version instead.

Also removes some irrelevant warnings from gymnasium about attribute access and auto disables env state recording if the state dictionary's leaves are not all the same batch size. Finally fixes a bug with enhanced determinism mode.