### PR TITLE
Fix flatten_state_dict with empty dictionary

### DIFF
--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -197,7 +197,7 @@ def flatten_state_dict(
     for key, value in state_dict.items():
         if isinstance(value, dict):
             state = flatten_state_dict(value, use_torch=use_torch)
-            if state.size == 0:
+            if state.nelement() == 0:
                 state = None
             if use_torch:
                 state = to_tensor(state, device=device)

--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -199,7 +199,7 @@ def flatten_state_dict(
             state = flatten_state_dict(value, use_torch=use_torch)
             if state.nelement() == 0:
                 state = None
-            if use_torch:
+            elif use_torch:
                 state = to_tensor(state, device=device)
         elif isinstance(value, (tuple, list)):
             state = None if len(value) == 0 else value


### PR DESCRIPTION
[torch.Tensor.size](https://pytorch.org/docs/stable/generated/torch.Tensor.size.html) returns as tensor.Size object when the dimension is not specified, making this check failing:
https://github.com/haosulab/ManiSkill/blob/b9c17c8e9af4b831178a55151d5434c99de448cc/mani_skill/utils/common.py#L200-L201