### PR TITLE
fix: allow users to set agents' collision groups by depth

### DIFF
--- a/mani_skill/agents/base_agent.py
+++ b/mani_skill/agents/base_agent.py
@@ -75,6 +75,9 @@ class BaseAgent:
     However for some robots/tasks it may be easier to disable all self collisions between links in the robot to increase simulation speed
     """
 
+    group_collisions_by_depth: bool = False
+    """Whether to set collision groups by depth. This is only used when loading .mjcf files."""
+
     keyframes: Dict[str, Keyframe] = dict()
     """a dict of predefined keyframes similar to what Mujoco does that you can use to reset the agent to that may be of interest"""
 
@@ -157,11 +160,14 @@ class BaseAgent:
         elif self.mjcf_path is not None:
             loader = self.scene.create_mjcf_loader()
             asset_path = format_path(str(self.mjcf_path))
+        else:
+            raise ValueError("One of urdf_path or mjcf_path must be provided")
 
         loader.name = self.uid
         if self._agent_idx is not None:
             loader.name = f"{self.uid}-agent-{self._agent_idx}"
         loader.fix_root_link = self.fix_root_link
+        loader.group_collisions_by_depth = self.group_collisions_by_depth
         loader.load_multiple_collisions_from_file = self.load_multiple_collisions
         loader.disable_self_collisions = self.disable_self_collisions
 


### PR DESCRIPTION
- When there are 32+ bodies in a `.mjcf` file, `ActorBuilder.collision_groups[2]` is greater than $2^{32} - 1$ which causes an error since the C++ interface expects the elements of `ActorBuilder.collision_groups` to be `uint32`
- This is due to the way that collision groups are set [here](https://github.com/haosulab/ManiSkill/blob/8e77db05769dac12ceaa3c01972da9b6271a1aef/mani_skill/utils/building/_mjcf_loader.py#L715) and leads to an error [here](https://github.com/haosulab/SAPIEN/blob/c877626fdefda29b2c33bea64f17830246508f05/python/py_package/wrapper/actor_builder.py#L251) when setting the collision groups since they are supposed to be `uint32`
- Changes:
  - if more than 32 bodies are found, thow an error when loading the `.mjcf`, rather than later
  - propose an alternative which sets the collision group based on the depth from the root body node of the `.mjcf` so there are less collision groups
    - this is off by default and enabled by setting `group_collisions_by_depth = True` in the agent class
    - Not sure if this is the right way to do this, open to alternatives