### PR TITLE
Fix documentation for torch_deterministic parameter in ppo.py

### DIFF
--- a/examples/baselines/ppo/ppo.py
+++ b/examples/baselines/ppo/ppo.py
@@ -28,7 +28,7 @@ class Args:
     seed: int = 1
     """seed of the experiment"""
     torch_deterministic: bool = True
-    """if toggled, `torch.backends.cudnn.deterministic=False`"""
+    """if toggled, `torch.backends.cudnn.deterministic=True`"""
     cuda: bool = True
     """if toggled, cuda will be enabled by default"""
     track: bool = False


### PR DESCRIPTION
This PR fixes the documentation inconsistency in `examples/baselines/ppo/ppo.py` regarding the `torch_deterministic` parameter.

The current docstring indicates that when the parameter is toggled, it sets `torch.backends.cudnn.deterministic=False`. However, this is inconsistent with:
1. The default value being set to `True`
2. The maintainer's confirmation that it should remain `True` for better reproducibility in RL

Changes made:
- Updated the docstring to correctly reflect that when toggled, it sets `torch.backends.cudnn.deterministic=True`

This change aligns the documentation with the actual intended behavior of the parameter.

Fixes #737