### PR TITLE
added property to base env for benchmarking

### DIFF
--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -351,6 +351,9 @@ class BaseEnv(gym.Env):
             """the original unbatched action space of the environment"""
         else:
             self.action_space = None
+        
+        self.fixed_trajectory = {}
+        
         # initialize the cached properties
         self.single_observation_space
         self.observation_space


### PR DESCRIPTION
After genesis base env setup, sapien env was not working due to the missing `fixed_trajectory` property. 