### PR TITLE
Fix: vector-gymnasium-wrapper -- fixing 'call' method -- getattr(self.env...) …

### DIFF
--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -159,7 +159,7 @@ class ManiSkillVectorEnv(VectorEnv):
         return self._env.close()
 
     def call(self, name: str, *args, **kwargs):
-        function = getattr(self.env, name)
+        function = getattr(self._env, name)
         return function(*args, **kwargs)
 
     def get_attr(self, name: str):


### PR DESCRIPTION
Fixing tiny bug in `ManiSkill/mani_skill/vector/wrappers/gymnasium.py`, in function `call`, line 162: 
from 
`function = getattr(self.env, name)`
to 
`function = getattr(self._env, name)`