### PR TITLE
Remove unnecessary conversion of `info` to NumPy (#791)

### DIFF
--- a/mani_skill/utils/wrappers/record.py
+++ b/mani_skill/utils/wrappers/record.py
@@ -514,7 +514,6 @@ class RecordEpisode(gym.Wrapper):
                 )
             else:
                 self._trajectory_buffer.fail = None
-            self._last_info = common.to_numpy(info)
 
         if self.save_video:
             self._video_steps += 1


### PR DESCRIPTION
The conversion of `info` to NumPy in `self._last_info` is unnecessary as `self._last_info` is never used. This line could also raise exceptions for certain `info` dictionaries. Fixes #791.