### PR TITLE
[BugFix] Fixed dtype error when running TD-MPC2 on anymalc-reach

### DIFF
--- a/examples/baselines/tdmpc2/common/math.py
+++ b/examples/baselines/tdmpc2/common/math.py
@@ -71,7 +71,7 @@ def two_hot(x, cfg):
 		return symlog(x)
 	x = torch.clamp(symlog(x), cfg.vmin, cfg.vmax).squeeze(1)
 	bin_idx = torch.floor((x - cfg.vmin) / cfg.bin_size).long()
-	bin_offset = ((x - cfg.vmin) / cfg.bin_size - bin_idx.float()).unsqueeze(-1)
+	bin_offset = ((x - cfg.vmin) / cfg.bin_size - bin_idx.float()).unsqueeze(-1).to(torch.float32)
 	soft_two_hot = torch.zeros(x.size(0), cfg.num_bins, device=x.device)
 	soft_two_hot.scatter_(1, bin_idx.unsqueeze(1), 1 - bin_offset)
 	soft_two_hot.scatter_(1, (bin_idx.unsqueeze(1) + 1) % cfg.num_bins, bin_offset)


### PR DESCRIPTION
When running anymalc-reach on gpu, the dtype for bin_offset in TD-MPC2's custom two_hot function becomes torch.float64, instead of torch.float32 in other tasks. Adding a dtype conversion fixed the minor bug.