### PR TITLE
[BugFix] Improve PPO default parameters and fix bug with lazy init sensors/cameras

### DIFF
--- a/examples/baselines/ppo/baselines.sh
+++ b/examples/baselines/ppo/baselines.sh
@@ -26,8 +26,8 @@ done
 for seed in ${seeds[@]}
 do
   python ppo_fast.py --env_id="PushT-v1" --seed=${seed} \
-    --num_envs=4096 --update_epochs=8 --num_minibatches=32 --gamma=0.99 \
-    --total_timesteps=50_000_000 --num-steps=16 --num_eval_steps=100 \
+    --num_envs=4096 --num-steps=16 --update_epochs=8 --num_minibatches=32 --gamma=0.99 \
+    --total_timesteps=50_000_000 --num_eval_steps=100 \
     --num_eval_envs=16 \
     --save-model --cudagraphs --exp-name="ppo-PushT-v1-state-${seed}-walltime_efficient" \
     --wandb_entity="stonet2000" --track
@@ -156,21 +156,9 @@ done
 
 for seed in ${seeds[@]}
 do
-  # no partial reset is used to help get higher success_at_end success rates
-  python ppo_rgb.py --env_id="AnymalC-Reach-v1" --seed=${seed} \
-    --num_envs=256 --update_epochs=8 --num_minibatches=32 \
-    --total_timesteps=50_000_000 --num-steps=200 --num-eval-steps=200 \
-    --gamma=0.99 --gae_lambda=0.95 \
-    --num_eval_envs=16 --no-partial-reset \
-    --exp-name="ppo-AnymalC-Reach-v1-rgb-${seed}-walltime_efficient" \
-    --wandb_entity="stonet2000" --track
-done
-
-for seed in ${seeds[@]}
-do
   python ppo_rgb.py --env_id="PushT-v1" --seed=${seed} \
-    --num_envs=256 --update_epochs=8 --num_minibatches=8 \
-    --total_timesteps=50_000_000 --num-steps=100 --num_eval_steps=100 --gamma=0.99 \
+    --num_envs=1024 --num-steps=16 --update_epochs=8 --num_minibatches=32 \
+    --total_timesteps=50_000_000 --num_eval_steps=100 --gamma=0.99 \
     --num_eval_envs=16 \
     --exp-name="ppo-PushT-v1-rgb-${seed}-walltime_efficient" \
     --wandb_entity="stonet2000" --track

--- a/examples/baselines/ppo/baselines.sh
+++ b/examples/baselines/ppo/baselines.sh
@@ -147,7 +147,7 @@ done
 for seed in ${seeds[@]}
 do
   python ppo_rgb.py --env_id="PickCube-v1" --seed=${seed} \
-    --num_envs=256 --update_epochs=8 --num_minibatches=8 \
+    --num_envs=1024 --num-steps=8 --update_epochs=8 --num_minibatches=32 \
     --total_timesteps=50_000_000 \
     --num_eval_envs=16 \
     --exp-name="ppo-PickCube-v1-rgb-${seed}-walltime_efficient" \

--- a/examples/baselines/ppo/ppo.py
+++ b/examples/baselines/ppo/ppo.py
@@ -101,7 +101,7 @@ class Args:
     """evaluation frequency in terms of iterations"""
     save_train_video_freq: Optional[int] = None
     """frequency to save training videos in terms of iterations"""
-    finite_horizon_gae: bool = True
+    finite_horizon_gae: bool = False
 
 
     # to be filled in runtime

--- a/examples/baselines/ppo/ppo_rgb.py
+++ b/examples/baselines/ppo/ppo_rgb.py
@@ -108,7 +108,7 @@ class Args:
     """evaluation frequency in terms of iterations"""
     save_train_video_freq: Optional[int] = None
     """frequency to save training videos in terms of iterations"""
-    finite_horizon_gae: bool = True
+    finite_horizon_gae: bool = False
 
     # to be filled in runtime
     batch_size: int = 0


### PR DESCRIPTION
finite_horizon_gae was a trick used before for CPU sims that worked sometimes but it is not as useful with smaller steps per environment in GPU sim training so it is turned off by default now.