### PR TITLE
[BugFix] Fix usage of the MS_ASSET_DIR variable

### DIFF
--- a/docs/source/user_guide/getting_started/installation.md
+++ b/docs/source/user_guide/getting_started/installation.md
@@ -39,6 +39,18 @@ python -m mani_skill.examples.demo_random_action
 A docker image is also provided on [Docker Hub](https://hub.docker.com/repository/docker/haosulab/mani-skill/general) called  `haosulab/mani-skill` and its corresponding [Dockerfile](https://github.com/haosulab/ManiSkill/blob/main/docker/Dockerfile).
 
 Once you are done here, you can head over to the [quickstart page](./quickstart.md) to try out some live demos and start to program with ManiSkill.
+
+There are also 2 environment variables that you may want to set. There are many assets, demonstration datasets etc. that are not downloaded by default. Modify `MS_ASSET_DIR` to the directory where you want to save all the data for ManiSkill, which by default is `~/.maniskill/data`.
+
+```bash
+export MS_ASSET_DIR=path/to/where/to/save/all/mani_skill_data
+```
+
+You can also do the following to skip the prompt to download the assets, meaning if you run code that needs access to assets that are not found, it will no longer prompt you to download them.
+```bash
+export MS_SKIP_ASSET_DOWNLOAD_PROMPT=1
+```
+
 <!-- 
 ## Soft-body tasks / Warp (ManiSkill-version)
 

--- a/mani_skill/__init__.py
+++ b/mani_skill/__init__.py
@@ -12,10 +12,16 @@ PACKAGE_DIR = Path(__file__).parent.resolve()
 PACKAGE_ASSET_DIR = PACKAGE_DIR / "assets"
 # Non-package data
 ASSET_DIR = Path(
-    os.getenv("MS_ASSET_DIR", os.path.join(os.path.expanduser("~"), ".maniskill/data"))
+    os.path.join(
+        os.getenv("MS_ASSET_DIR", os.path.join(os.path.expanduser("~"), ".maniskill")),
+        "data",
+    )
 )
 DEMO_DIR = Path(
-    os.getenv("MS_ASSET_DIR", os.path.join(os.path.expanduser("~"), ".maniskill/demos"))
+    os.path.join(
+        os.getenv("MS_ASSET_DIR", os.path.join(os.path.expanduser("~"), ".maniskill")),
+        "demos",
+    )
 )
 
 

--- a/mani_skill/utils/download_asset.py
+++ b/mani_skill/utils/download_asset.py
@@ -17,6 +17,9 @@ from mani_skill.utils.assets.data import DATA_GROUPS, DATA_SOURCES
 
 
 def prompt_yes_no(message):
+    skip_prompt = os.getenv("MS_SKIP_ASSET_DOWNLOAD_PROMPT")
+    if skip_prompt == "1":
+        return True
     r"""Prints a message and prompts the user for "y" or "n" returning True or False."""
     # https://github.com/facebookresearch/habitat-sim/blob/main/src_python/habitat_sim/utils/datasets_download.py
     print("\n-------------------------")


### PR DESCRIPTION
Previously if one sets MS_ASSET_DIR, assets and demos are put in the same folder, not separate ones.

Moreover one can do `export MS_SKIP_ASSET_DOWNLOAD_PROMPT=1` to autodownload missing assets instead of prompting at the terminal.