### PR TITLE
Fixed final_info having wrong elapsed_steps value after reset and final_observation being wrong on CUDA

### DIFF
--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -16,6 +16,23 @@ from mani_skill.utils.structs.types import Array, Device
 # Utilities for working with tensors, numpy arrays, and batched data
 # -------------------------------------------------------------------------- #
 
+def torch_clone_dict(data: dict) -> dict:
+    """
+    Recursively clones all torch tensors in a dictionary.
+    If the input was a torch tensor, it will return a clone of the tensor.
+    """
+    if isinstance(data, torch.Tensor):
+        return data.clone()
+    
+    output_dict = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            output_dict[key] = torch_clone_dict(value)
+        elif isinstance(value, torch.Tensor):
+            output_dict[key] = value.clone()
+        else:
+            output_dict[key] = value
+    return output_dict
 
 def _batch(array: Union[Array, Sequence]):
     if isinstance(array, (dict)):

--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import gymnasium as gym
 import torch
-import copy
 from gymnasium.vector import VectorEnv
 
 from mani_skill.utils.structs.types import Array
+from mani_skill.utils.common import torch_clone_dict
 
 if TYPE_CHECKING:
     from mani_skill.envs.sapien_env import BaseEnv
@@ -142,9 +142,9 @@ class ManiSkillVectorEnv(VectorEnv):
         dones = torch.logical_or(terminations, truncations)
 
         if dones.any() and self.auto_reset:
-            final_obs = copy.deepcopy(obs)
+            final_obs = torch_clone_dict(obs)
             env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
-            final_info = copy.deepcopy(infos)
+            final_info = torch_clone_dict(infos)
             obs, infos = self.reset(options=dict(env_idx=env_idx))
             # gymnasium calls it final observation but it really is just o_{t+1} or the true next observation
             infos["final_observation"] = final_obs

--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import gymnasium as gym
 import torch
+import copy
 from gymnasium.vector import VectorEnv
 
 from mani_skill.utils.structs.types import Array
@@ -143,8 +144,8 @@ class ManiSkillVectorEnv(VectorEnv):
         if dones.any() and self.auto_reset:
             final_obs = obs
             env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
+            infos["final_info"] = copy.deepcopy(infos)
             obs, _ = self.reset(options=dict(env_idx=env_idx))
-            infos["final_info"] = infos.copy()
             # gymnasium calls it final observation but it really is just o_{t+1} or the true next observation
             infos["final_observation"] = final_obs
             # NOTE (stao): that adding masks like below is a bit redundant and not necessary

--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -144,10 +144,11 @@ class ManiSkillVectorEnv(VectorEnv):
         if dones.any() and self.auto_reset:
             final_obs = obs
             env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
-            infos["final_info"] = copy.deepcopy(infos)
-            obs, _ = self.reset(options=dict(env_idx=env_idx))
+            final_info = copy.deepcopy(infos)
+            obs, infos = self.reset(options=dict(env_idx=env_idx))
             # gymnasium calls it final observation but it really is just o_{t+1} or the true next observation
             infos["final_observation"] = final_obs
+            infos["final_info"] = final_info
             # NOTE (stao): that adding masks like below is a bit redundant and not necessary
             # but this is to follow the standard gymnasium API
             infos["_final_info"] = dones

--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -142,7 +142,7 @@ class ManiSkillVectorEnv(VectorEnv):
         dones = torch.logical_or(terminations, truncations)
 
         if dones.any() and self.auto_reset:
-            final_obs = obs
+            final_obs = copy.deepcopy(obs)
             env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
             final_info = copy.deepcopy(infos)
             obs, infos = self.reset(options=dict(env_idx=env_idx))


### PR DESCRIPTION
# Description
- Because `BaseEnv::get_info` does not always clone the `elapsed_steps`, the dict still pointed to the same tensor therefore the `env.reset` would change the `elapsed_steps` stored (even if it's a new dict, the value was still the same tensor) which would invalidate the `final_info` data.
- My change is local to the vect env to prevent major change across the code base, an alternative would be to make `BaseEnv::get_info` always clone the `elapsed_steps` but since there is currently an `if` statement that prevents this I assume this is for a specific reason, so I decided to not change `BaseEnv::get_info`.  
```python
def get_info(self) -> dict:
        """
        Get info about the current environment state, include elapsed steps and evaluation information
        """
        info = dict(
            elapsed_steps=self.elapsed_steps
            if not self.gpu_sim_enabled
            else self._elapsed_steps.clone()
        )
        info.update(self.evaluate())
        return info
```  
[source](https://github.com/haosulab/ManiSkill/blob/a1bc12628ebc6ac48c2150b6bd79e36908055fb3/mani_skill/envs/sapien_env.py#L1016C5-L1026C20)

# TLDR:   
If we take for example a task with auto_reset and a max traj length of 50 (eg: Push Cube).  
## Before This PR    
```
obs, info = env.step(...) # info["elapsed_steps"] would be 49
obs, info = env.step(...) # info["elapsed_steps"] would be 0 (since we use auto_reset)
print(info["final_info"]["elapsed_steps"]) # Gives 0 (wrong!)
```
## After This PR    
```
obs, info = env.step(...) # info["elapsed_steps"] would be 49
obs, info = env.step(...) # info["elapsed_steps"] would be 0 (since we use auto_reset)
print(info["final_info"]["elapsed_steps"]) # Gives 50 (the true elapsed_steps of the true last observation) 
```
