### PR TITLE
[BugFix] Fix initial poses of static objects in AI2THOR scenes to be not zero in CPU and GPU sim.

### DIFF
--- a/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
+++ b/mani_skill/utils/scene_builder/ai2thor/scene_builder.py
@@ -204,11 +204,9 @@ class AI2THORBaseSceneBuilder(SceneBuilder):
                         object["translation"][1] + 0,
                     ]
                     pose = sapien.Pose(p=position, q=q)
-                    builder.add_visual_from_file(str(model_path), pose=pose)
-                    builder.add_nonconvex_collision_from_file(
-                        str(model_path), pose=pose
-                    )
-                    builder.initial_pose = sapien.Pose()
+                    builder.add_visual_from_file(str(model_path))
+                    builder.add_nonconvex_collision_from_file(str(model_path))
+                    builder.initial_pose = pose
                     builder.set_scene_idxs(env_idx)
                     actor = builder.build_static(name=f"{unique_id}_{actor_name}")
                 else:


### PR DESCRIPTION
Previously the code initialized the meshes at the pose of the object instead of the whole object at that pose. Closes #805 