### PR TITLE
Fix agents' qpos type to be floats

### DIFF
--- a/mani_skill/agents/robots/dclaw/dclaw.py
+++ b/mani_skill/agents/robots/dclaw/dclaw.py
@@ -32,7 +32,7 @@ class DClaw(BaseAgent):
     keyframes = dict(
         rest=Keyframe(
             pose=sapien.Pose(p=[0, 0, 0.5], q=[0, 0, -1, 0]),
-            qpos=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            qpos=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
         )
     )
 

--- a/mani_skill/agents/robots/floating_robotiq_2f_85_gripper/floating_robotiq_2f_85_gripper.py
+++ b/mani_skill/agents/robots/floating_robotiq_2f_85_gripper/floating_robotiq_2f_85_gripper.py
@@ -32,11 +32,11 @@ class FloatingRobotiq2F85Gripper(BaseAgent):
     )
     keyframes = dict(
         open_facing_up=Keyframe(
-            qpos=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            qpos=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             pose=sapien.Pose(p=np.array([0.0, 0.0, 0.5])),
         ),
         open_facing_side=Keyframe(
-            qpos=[0, 0, 0, 0, 0, 0],
+            qpos=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             pose=sapien.Pose(
                 p=np.array([0.0, 0.0, 0.5]), q=np.array([0.7071, 0, 0.7071, 0])
             ),


### PR DESCRIPTION
ManiSkill will crash when running on GPU for 2 robots (`floating_robotiq_2f_85_gripper` and `dclaw`) since the `qpos` in the keyframes are interpreted to be `Long` type while they are assumed to be floats in the code.

Running:
```python
CUDA_VISIBLE_DEVICES=0 python -m mani_skill.examples.demo_robot -r "floating_robotiq_2f_85_gripper" -b gpu
```
gives the error:
```
Selected robot floating_robotiq_2f_85_gripper. Control mode: pd_joint_pos
Selected Robot has the following keyframes to view: 
dict_keys(['open_facing_up', 'open_facing_side'])
...
File ".../mani_skill/utils/structs/articulation.py", line 622, in qpos
    self.px.cuda_articulation_qpos.torch()[
RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and Long for the source.
```

This is a simple fix where the `qpos` values of the two robots are changed to floats.