### PR TITLE
[BugFix] Fix slow CPU sim and fix the CPU sim benchmark code to be faster

### DIFF
--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1088,7 +1088,8 @@ class BaseEnv(gym.Env):
             sub_scenes,
             sim_config=self.sim_config,
             device=self.device,
-            parallel_in_single_scene=self._parallel_in_single_scene
+            parallel_in_single_scene=self._parallel_in_single_scene,
+            backend=self.backend
         )
         self.scene.px.timestep = 1.0 / self._sim_freq
 

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -9,6 +9,7 @@ import sapien.render
 import torch
 from sapien.render import RenderCameraComponent
 
+from mani_skill.envs.utils.system.backend import BackendInfo
 from mani_skill.render import SAPIEN_RENDER_SYSTEM
 from mani_skill.sensors.base_sensor import BaseSensor
 from mani_skill.sensors.camera import Camera
@@ -51,6 +52,7 @@ class ManiSkillScene:
         debug_mode: bool = True,
         device: Device = None,
         parallel_in_single_scene: bool = False,
+        backend: BackendInfo = None,
     ):
         if sub_scenes is None:
             sub_scenes = [sapien.Scene()]
@@ -69,6 +71,7 @@ class ManiSkillScene:
         self._gpu_sim_initialized = False
         self.debug_mode = debug_mode
         self.device = device
+        self.backend = backend  # references the backend object stored in BaseEnv class
 
         self.render_system_group: sapien.render.RenderSystemGroup = None
         self.camera_groups: Dict[str, sapien.render.RenderCameraGroup] = dict()

--- a/mani_skill/envs/utils/system/backend.py
+++ b/mani_skill/envs/utils/system/backend.py
@@ -63,7 +63,8 @@ def parse_sim_and_render_backend(sim_backend: str, render_backend: str) -> Backe
     elif render_backend[:4] == "cuda":
         render_device = sapien.Device(render_backend)
     else:
-        raise ValueError(f"Invalid render backend: {render_backend}")
+        # handle special cases such as for AMD gpus, render_backend must be defined as pci:... instead as cuda is not available.
+        render_device = sapien.Device(render_backend)
     return BackendInfo(
         device=device,
         sim_device=sim_device,

--- a/mani_skill/utils/structs/articulation_joint.py
+++ b/mani_skill/utils/structs/articulation_joint.py
@@ -245,7 +245,7 @@ class ArticulationJoint(BaseStruct[physx.PhysxArticulationJoint]):
                 arg1 = arg1.reshape(
                     1,
                 )
-            self._objs[0].drive_target = arg1
+            self._objs[0].drive_target = arg1.numpy()
 
     @property
     def drive_velocity_target(self) -> torch.Tensor:

--- a/mani_skill/utils/structs/render_camera.py
+++ b/mani_skill/utils/structs/render_camera.py
@@ -168,10 +168,18 @@ class RenderCamera:
             elif SAPIEN_RENDER_SYSTEM == "3.1":
                 return [x.torch() for x in self.camera_group.get_cuda_pictures(names)]
         else:
-            return [
-                common.to_tensor(self._render_cameras[0].get_picture(name))[None, ...]
-                for name in names
-            ]
+            if self.scene.backend.render_backend == "cuda":
+                return [
+                    self._render_cameras[0].get_picture_cuda(name).torch()[None, ...]
+                    for name in names
+                ]
+            else:
+                return [
+                    common.to_tensor(self._render_cameras[0].get_picture(name))[
+                        None, ...
+                    ]
+                    for name in names
+                ]
 
     # def get_picture_cuda(self, name: str):
     #     return self._render_cameras[0].get_picture_cuda(name)


### PR DESCRIPTION
Closes #817 

- CPU sim was defaulting to using the generic `get_picture` function in sapien, which works cross-platform (amd, intel, cuda-enabled gpus) but is not as fast as `get_picture_cuda` which works just for cuda enabled GPUs. multi-processing parallelization with visual observation modes are now fast again, and despite the torch overhead of internal code is faster than maniskill2 neatly.

- CPU sim benchmarking code has been upgraded and is now faster. The core problems from before is that passing actions as torch tensors, while allowed, is extremely slow for the gymnasium async vector env implementation. I'm not sure why, but simply doing env.step(actions.numpy()) increased pick cube FPS from 1600 to about 2200 with 8 parallel CPU envs.

- Wrap CPUGymWrapper around in the benchmark code to convert all returned data from the sim to numpy and be unbatched. This fixes the observation space (which had an extra dimension before in benchmarking) but importantly is far faster. Again gymnasium async vector env implementation does not like torch tensors. Also a similar improvement in FPS magnitude wise

- For setting joint drive targets torch tensors are converted to numpy first before being passed. This yields a very small improvement in FPS (probably not noticeable). It seems pybind wrapper around sapien does not convert torch tensor data (despite being on the CPU) very fast.

This should also make all the imitation learning baselines run far far faster now when evaluating with the physx_cpu backend, especially when using visual observations (only for cuda enabled GPUS however, non cuda enabled GPUs will not run any faster when rendering with parallel envs via multiprocessing).