### PR TITLE
Fix crash in CPU backend for multi-body Actors

### DIFF
--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -211,7 +211,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
                 return self._body_data[self._body_data_index, 7:10]
             return self._body_data[self._body_data_index, 10:13]
         else:
-            return torch.from_numpy(self._bodies[0].angular_velocity[None, :])
+            return torch.Tensor([body.linear_velocity for body in self._bodies])
 
     @property
     def auto_compute_mass(self) -> torch.Tensor:
@@ -432,7 +432,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
                 return self._body_data[self._body_data_index, 10:13]
             return self._body_data[self._body_data_index, 7:10]
         else:
-            return torch.from_numpy(self._bodies[0].linear_velocity[None, :])
+            return torch.Tensor([body.linear_velocity for body in self._bodies])
 
     @linear_velocity.setter
     def linear_velocity(self, arg1: Array):


### PR DESCRIPTION
When running an environment with multiple bodies merged into a single Actor and running with a CPU backend, the program will crash due to `BaseStruct.linear_velocity` always returning a [1, 3] tensor instead of [N, 3]. For a GPU backend, it works as expected. 

From my examination, it should be enough to change the return value in the `linear_velocity` property to:

```python
return torch.from_numpy(self._bodies[0].linear_velocity[None, :])
```

to 

```python
return torch.Tensor([body.linear_velocity for body in self._bodies])
```

And similarly for `angular_velocity`.

Test code for verification:

```python
@register_env("Test-v1", max_episode_steps=50, asset_download_ids=["ycb"], override=True)
class TestEnv(PickClutterYCBEnv):
    def _load_scene(self, options: dict):

        # use the _load_scene from PickClutterYCBEnv
        super(PickClutterYCBEnv, self)._load_scene(options)

        # remove all the single actors from the state_dict
        for actor_list in self.selectable_target_objects:
            for actor in actor_list:
                self.remove_from_state_dict_registry(actor)

        # add the merged actor
        self.add_to_state_dict_registry(self.all_objects)


env: BaseEnv = gym.make(
    'Test-v1',
    obs_mode='rgb+depth',
    render_mode='sensors',
    num_envs=1,
    sim_backend='cpu',
    )

obs, info = env.reset()
```