### PR TITLE
[BugFix] create numpy array first then torch tensor for some properties

### DIFF
--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -211,7 +211,9 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
                 return self._body_data[self._body_data_index, 7:10]
             return self._body_data[self._body_data_index, 10:13]
         else:
-            return torch.tensor([body.linear_velocity for body in self._bodies])
+            return torch.tensor(
+                np.array([body.angular_velocity for body in self._bodies])
+            )
 
     @property
     def auto_compute_mass(self) -> torch.Tensor:
@@ -432,7 +434,9 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
                 return self._body_data[self._body_data_index, 10:13]
             return self._body_data[self._body_data_index, 7:10]
         else:
-            return torch.tensor([body.linear_velocity for body in self._bodies])
+            return torch.tensor(
+                np.array([body.linear_velocity for body in self._bodies])
+            )
 
     @linear_velocity.setter
     def linear_velocity(self, arg1: Array):


### PR DESCRIPTION
removes torch warning about torch.tensor(list_of_np_arrays) being very slow.