### PR TITLE
fix gpu sim demo, mem type is None

### DIFF
--- a/docs/source/user_guide/getting_started/docker.md
+++ b/docs/source/user_guide/getting_started/docker.md
@@ -19,8 +19,8 @@ You should be able to run both CPU and GPU simulation, which you can test below
 
 ```bash
 docker pull maniskill/base
-docker run --rm -it --gpus all maniskill/base python -m mani_skill.examples.demo_random_action
-docker run --rm -it --gpus all maniskill/base python -m mani_skill.examples.benchmarking.gpu_sim
+docker run --rm -it --gpus all --pid host maniskill/base python -m mani_skill.examples.demo_random_action
+docker run --rm -it --gpus all --pid host maniskill/base python -m mani_skill.examples.benchmarking.gpu_sim
 ```
 
 Note that inside a docker image you generally cannot render a GUI to see the results. You can still record videos and the demo scripts have options to record videos instead of rendering a GUI.


### PR DESCRIPTION
When using the docker container, I noticed that the GPU mem used in gpu sim demo was 0. There is a fix already suggested for that in the following issue. 
https://github.com/haosulab/ManiSkill/issues/650
by adding `--pid host` the gpus are utilized from inside the container.
Lets add this line to the docs to pervent others from having trouble with docker.
[Solution](https://github.com/haosulab/ManiSkill/issues/650#issuecomment-2434812353)