### PR TITLE
[BugFix] Fix bug where articulations built with initial poses not at 0 would have incorrectly generated collision meshes + deprecate old get articulation meshes function

### DIFF
--- a/mani_skill/utils/building/articulations/partnet_mobility.py
+++ b/mani_skill/utils/building/articulations/partnet_mobility.py
@@ -1,10 +1,6 @@
 from mani_skill import ASSET_DIR, PACKAGE_ASSET_DIR
 from mani_skill.envs.scene import ManiSkillScene
 from mani_skill.utils import sapien_utils
-from mani_skill.utils.geometry.trimesh_utils import (
-    get_articulation_meshes,
-    merge_meshes,
-)
 from mani_skill.utils.io_utils import load_json
 
 PARTNET_MOBILITY = None

--- a/mani_skill/utils/geometry/trimesh_utils.py
+++ b/mani_skill/utils/geometry/trimesh_utils.py
@@ -102,18 +102,3 @@ def get_actor_visual_mesh(actor: sapien.Entity):
     if mesh is None:
         return None
     return mesh
-
-
-def get_articulation_meshes(
-    articulation: physx.PhysxArticulation, exclude_link_names=()
-):
-    """Get link meshes in the world frame."""
-    meshes = []
-    for link in articulation.get_links():
-        if link.name in exclude_link_names:
-            continue
-        mesh = get_component_mesh(link, True)
-        if mesh is None:
-            continue
-        meshes.append(mesh)
-    return meshes

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -364,14 +364,6 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
             meshes.append(mesh)
             if first_only:
                 break
-        if to_world_frame:
-            mat = self.pose
-            for i, mesh in enumerate(meshes):
-                if mat is not None:
-                    if len(mat) > 1:
-                        mesh.apply_transform(mat[i].sp.to_transformation_matrix())
-                    else:
-                        mesh.apply_transform(mat.sp.to_transformation_matrix())
         if first_only:
             return meshes[0]
         return meshes


### PR DESCRIPTION
Closes #926 

And deprecates the old get_articulation_meshes function (that was cpu sim only) in favor of the object oriented version articulation.get_collision_meshes or articulation.get_first_collision_mesh (which caused confusion in e.g. #887 )