### PR TITLE
Adding missing `.cpu()` calls in stack_cube.py, peg_insertion_side.py

### DIFF
--- a/mani_skill/examples/motionplanning/panda/solutions/peg_insertion_side.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/peg_insertion_side.py
@@ -53,7 +53,7 @@ def solve(env: PegInsertionSideEnv, seed=None, debug=False, vis=False):
     )
     closing, center = grasp_info["closing"], grasp_info["center"]
     grasp_pose = env.agent.build_grasp_pose(approaching, closing, center)
-    offset = sapien.Pose([-max(0.05, env.peg_half_sizes[0, 0] / 2 + 0.01), 0, 0])
+    offset = sapien.Pose([-max(0.05, env.peg_half_sizes[0, 0].item() / 2 + 0.01), 0, 0])
     grasp_pose = grasp_pose * (offset)
 
     # -------------------------------------------------------------------------- #
@@ -75,7 +75,7 @@ def solve(env: PegInsertionSideEnv, seed=None, debug=False, vis=False):
 
     # align the peg with the hole
     insert_pose = env.goal_pose * peg_init_pose.inv() * grasp_pose
-    offset = sapien.Pose([-0.01 - env.peg_half_sizes[0, 0], 0, 0])
+    offset = sapien.Pose([-0.01 - env.peg_half_sizes[0, 0].item(), 0, 0])
     pre_insert_pose = insert_pose * (offset)
     res = planner.move_to_pose_with_screw(pre_insert_pose)
     if res == -1: return res

--- a/mani_skill/examples/motionplanning/panda/solutions/peg_insertion_side.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/peg_insertion_side.py
@@ -44,7 +44,7 @@ def solve(env: PegInsertionSideEnv, seed=None, debug=False, vis=False):
 
     obb = get_actor_obb(env.peg)
     approaching = np.array([0, 0, -1])
-    target_closing = env.agent.tcp.pose.to_transformation_matrix()[0, :3, 1].numpy()
+    target_closing = env.agent.tcp.pose.to_transformation_matrix()[0, :3, 1].cpu().numpy()
 
     peg_init_pose = env.peg.pose
 

--- a/mani_skill/examples/motionplanning/panda/solutions/stack_cube.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/stack_cube.py
@@ -76,8 +76,8 @@ def solve(env: StackCubeEnv, seed=None, debug=False, vis=False):
     # -------------------------------------------------------------------------- #
     # Stack
     # -------------------------------------------------------------------------- #
-    goal_pose = env.cubeB.pose * sapien.Pose([0, 0, env.cube_half_size[2] * 2])
-    offset = (goal_pose.p - env.cubeA.pose.p).numpy()[0] # remember that all data in ManiSkill is batched and a torch tensor
+    goal_pose = env.cubeB.pose * sapien.Pose([0, 0, (env.cube_half_size[2] * 2).item()])
+    offset = (goal_pose.p - env.cubeA.pose.p).cpu().numpy()[0] # remember that all data in ManiSkill is batched and a torch tensor
     align_pose = sapien.Pose(lift_pose.p + offset, lift_pose.q)
     planner.move_to_pose_with_screw(align_pose)
 

--- a/mani_skill/examples/motionplanning/panda/solutions/stack_cube.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/stack_cube.py
@@ -30,7 +30,7 @@ def solve(env: StackCubeEnv, seed=None, debug=False, vis=False):
     obb = get_actor_obb(env.cubeA)
 
     approaching = np.array([0, 0, -1])
-    target_closing = env.agent.tcp.pose.to_transformation_matrix()[0, :3, 1].numpy()
+    target_closing = env.agent.tcp.pose.to_transformation_matrix()[0, :3, 1].cpu().numpy()
     grasp_info = compute_grasp_info_by_obb(
         obb,
         approaching=approaching,


### PR DESCRIPTION
Fixes a bug where .cpu() was missing in two files, causing an error:

```
Cannot find valid solution because of an error in motion planning solution: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```