### PR TITLE
[Feature] optimize HDF5 loading in RGB DP baseline.

### DIFF
--- a/mani_skill/utils/wrappers/record.py
+++ b/mani_skill/utils/wrappers/record.py
@@ -580,6 +580,7 @@ class RecordEpisode(gym.Wrapper):
                         for k in data.keys():
                             recursive_add_to_h5py(subgrp, data[k], k)
                     else:
+                        chunk_shape = (1,) + data.shape[2:]
                         if key == "rgb":
                             # NOTE(jigu): It is more efficient to use gzip than png for a sequence of images.
                             group.create_dataset(
@@ -588,6 +589,7 @@ class RecordEpisode(gym.Wrapper):
                                 dtype=data.dtype,
                                 compression="gzip",
                                 compression_opts=5,
+                                chunks=chunk_shape,
                             )
                         elif key == "depth":
                             # NOTE (stao): By default now cameras in ManiSkill return depth values of type uint16 for numpy
@@ -597,6 +599,7 @@ class RecordEpisode(gym.Wrapper):
                                 dtype=data.dtype,
                                 compression="gzip",
                                 compression_opts=5,
+                                chunks=chunk_shape,
                             )
                         elif key == "seg":
                             group.create_dataset(
@@ -605,6 +608,7 @@ class RecordEpisode(gym.Wrapper):
                                 dtype=data.dtype,
                                 compression="gzip",
                                 compression_opts=5,
+                                chunks=chunk_shape,
                             )
                         else:
                             group.create_dataset(


### PR DESCRIPTION
* Refactored the dataset to avoid preloading the entire dataset into memory during `__init__`.
* Deferred moving data to CUDA to avoid issues when `num_workers > 0` in DataLoader.
* Ensured each worker process opens its own HDF5 file to prevent shared file handle issues.
* Tuned HDF5 chunking settings to enable fast single-image access without loading entire trajectories.

⚠️ NOTE: This new version of the dataset requires HDF5 files generated with the updated chunking strategy.
Old-format files use chunking by trajectory (e.g. 24 frames per chunk), which makes single-frame access inefficient.
When using such files, reading one image will still trigger loading the entire chunk, causing significant slowdown.