### PR TITLE
Remove redundant `num_actors` definition

### DIFF
--- a/mani_skill/utils/building/actor_builder.py
+++ b/mani_skill/utils/building/actor_builder.py
@@ -202,7 +202,6 @@ class ActorBuilder(SAPIENActorBuilder):
             and self.name not in self.scene.actors
         ), "built actors in ManiSkill must have unique names and cannot be None or empty strings"
 
-        num_actors = self.scene.num_envs
         if self.scene_idxs is not None:
             self.scene_idxs = common.to_tensor(
                 self.scene_idxs, device=self.scene.device


### PR DESCRIPTION
Removes a redundant variable definition that is immediately redefined.

Note:

https://github.com/haosulab/ManiSkill/blob/b3f2cfdb20e4ff7494d50cf686e93c87a495986c/mani_skill/utils/building/actor_builder.py#L205-L212