### PR TITLE
Updated Pull Cube Default Camera Config To Show Cube & Target

### DIFF
--- a/mani_skill/envs/tasks/tabletop/pull_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pull_cube.py
@@ -43,7 +43,7 @@ class PullCubeEnv(BaseEnv):
 
     @property
     def _default_sensor_configs(self):
-        pose = look_at(eye=[0.3, 0, 0.6], target=[-0.1, 0, 0.1])
+        pose = look_at(eye=[-0.5,0.0,0.25], target=[0.2,0.0,-0.5])
         return [CameraConfig("base_camera", pose, 128, 128, np.pi / 2, 0.01, 100)]
 
     @property


### PR DESCRIPTION
This PR updates the default camera configuration for the `PullCube-v1` task. The new settings provide a more realistic and interpretable view, aligning closer to typical real-world camera setups.   
The old view made it hard or impossible to see the cube and target in most cases while the new one clearly shows the cube and target in a more natural way for this task.

| **Before** | **After (this PR)** |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
| <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/26939775/444376492-e531fcc2-37ac-48f7-bd1c-3b17798626c3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250516T042725Z&X-Amz-Expires=300&X-Amz-Signature=a167127118efb5b19a4bc1b1ccce81608288f9250001b2f3af4a47c87aa622db&X-Amz-SignedHeaders=host" height="300" width="300" />| <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/26939775/444644062-babe2eaa-f0ba-493c-b69b-f582488862e9.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250516T172449Z&X-Amz-Expires=300&X-Amz-Signature=056078c3d62f3a8717f9dbf51832785245eceb9a9bfa00957de51d8b769b0a06&X-Amz-SignedHeaders=host" height="300" width="300" /> | 

**DrQ-v2 (this PR)**   

https://github.com/user-attachments/assets/02343574-3037-43a2-b7e3-4d975a14372a
  
Note: I had to do some trials and errors to find a camera config that minimizes/prevents the arm from going through the camera. The final result is pretty solid in my opinion, I did not see such behavior with the final config I got.  
  
I also tried to keep the same POV than other tasks (camera showing the table horizontally, no tilt).