### PR TITLE
Add clamping to [-1, 1] for avoid nans in matrix_to_euler conversion

### DIFF
--- a/mani_skill/utils/geometry/rotation_conversions.py
+++ b/mani_skill/utils/geometry/rotation_conversions.py
@@ -291,10 +291,13 @@ def matrix_to_euler_angles(matrix: torch.Tensor, convention: str) -> torch.Tenso
     tait_bryan = i0 != i2
     if tait_bryan:
         central_angle = torch.asin(
-            matrix[..., i0, i2] * (-1.0 if i0 - i2 in [-1, 2] else 1.0)
+            torch.clamp(matrix[..., i0, i2], -1.0 + 1e-8, 1.0 - 1e-8)
+            * (-1.0 if i0 - i2 in [-1, 2] else 1.0)
         )
     else:
-        central_angle = torch.acos(matrix[..., i0, i0])
+        central_angle = torch.acos(
+            torch.clamp(matrix[..., i0, i0], -1.0 + 1e-8, 1.0 - 1e-8)
+        )
 
     o = (
         _angle_from_tan(


### PR DESCRIPTION
I encountered strange nan issues when converting from quat_wxyz to euler_ZYX like below:

```
        pos = pose_w[:, :3]
        quat_wxyz = pose_w[:, 3:]
        matrix = quaternion_to_matrix(quat_wxyz)
        euler_ZYX = matrix_to_euler_angles(matrix, "ZYX")
        return torch.cat([pos, euler_ZYX], dim=-1)
```

I found that the issue was from numerical issues making matrix contain values greater than 1 (e.g., 1 + 1e-6). The domain of `torch.acos` and `torch.asin` are [-1, 1], and they return nan if given values outside of this range. Thus, this simply adds clamping to the inputs to these functions to make them robust to these numerical issues.