### PR TITLE
[BugFix] Register missing asset download IDs for the TurnFaucet task

### DIFF
--- a/mani_skill/envs/tasks/tabletop/turn_faucet.py
+++ b/mani_skill/envs/tasks/tabletop/turn_faucet.py
@@ -20,7 +20,11 @@ from mani_skill.utils.structs.pose import Pose
 from mani_skill.utils.structs.types import SimConfig
 
 
-@register_env("TurnFaucet-v1", max_episode_steps=200)
+@register_env(
+    "TurnFaucet-v1",
+    max_episode_steps=200,
+    asset_download_ids=["partnet_mobility_faucet"],
+)
 class TurnFaucetEnv(BaseEnv):
     SUPPORTED_REWARD_MODES = ["sparse", "none"]
     SUPPORTED_ROBOTS = ["panda", "panda_wristcam", "fetch"]


### PR DESCRIPTION
Ensures #1010 doesn't happen without reasonable error message for user.