### PR TITLE
[Feature] Support CPU simulation only and fallback options if usable device is not found for rendering

### DIFF
--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -726,11 +726,11 @@ class BaseEnv(gym.Env):
         self._load_agent(options)
 
         self._load_scene(options)
-        self._load_lighting(options)
+        if self.scene.can_render(): self._load_lighting(options)
 
         self.scene._setup(enable_gpu=self.gpu_sim_enabled)
         # for GPU sim, we have to setup sensors after we call setup gpu in order to enable loading mounted sensors as they depend on GPU buffer data
-        self._setup_sensors(options)
+        if self.scene.can_render(): self._setup_sensors(options)
         if self.render_mode == "human" and self._viewer is None:
             self._viewer = create_viewer(self._viewer_camera_config)
         if self._viewer is not None:
@@ -1167,8 +1167,11 @@ class BaseEnv(gym.Env):
                 sub_scenes.append(scene)
         else:
             physx_system = physx.PhysxCpuSystem()
+            systems = [physx_system]
+            if self._render_device.can_render():
+                systems.append(sapien.render.RenderSystem(self._render_device))
             sub_scenes = [
-                sapien.Scene([physx_system, sapien.render.RenderSystem(self._render_device)])
+                sapien.Scene(systems)
             ]
         # create a "global" scene object that users can work with that is linked with all other scenes created
         self.scene = ManiSkillScene(
@@ -1179,6 +1182,9 @@ class BaseEnv(gym.Env):
             backend=self.backend
         )
         self.scene.px.timestep = 1.0 / self._sim_freq
+        if not self.scene.can_render():
+            if self.render_mode is not None:
+                logger.warning(f'The chosen render mode is "{self.render_mode}", but selected rendering device "{self.scene.backend.render_device}" does not support rendering')
 
     def _clear(self):
         """Clear the simulation scene instance and other buffers.

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1153,8 +1153,11 @@ class BaseEnv(gym.Env):
                     scene_idx % scene_grid_length - scene_grid_length // 2,
                     scene_idx // scene_grid_length - scene_grid_length // 2,
                 )
+                systems = [physx_system]
+                if self._render_device.can_render():
+                    systems.append(sapien.render.RenderSystem(self._render_device))
                 scene = sapien.Scene(
-                    systems=[physx_system, sapien.render.RenderSystem(self._render_device)]
+                    systems=systems
                 )
                 physx_system.set_scene_offset(
                     scene,

--- a/mani_skill/envs/scene.py
+++ b/mani_skill/envs/scene.py
@@ -115,6 +115,10 @@ class ManiSkillScene:
         )
         """state dict registry that map actor/articulation names to Actor/Articulation struct references. Only these structs are used for the environment state"""
 
+    def can_render(self):
+        """Whether or not this Scene object permits rendering, depending on the rendering device selected"""
+        return self.backend.render_device.can_render()
+
     # -------------------------------------------------------------------------- #
     # Functions from sapien.Scene
     # -------------------------------------------------------------------------- #

--- a/mani_skill/envs/utils/system/backend.py
+++ b/mani_skill/envs/utils/system/backend.py
@@ -44,7 +44,7 @@ render_backend_name_mapping = {
 
 def parse_sim_and_render_backend(sim_backend: str, render_backend: str) -> BackendInfo:
     sim_backend = sim_backend_name_mapping[sim_backend]
-    render_backend = render_backend_name_mapping[render_backend]
+    render_backend = render_backend_name_mapping.get(render_backend, render_backend)
     if sim_backend == "physx_cpu":
         device = torch.device("cpu")
         sim_device = sapien.Device("cpu")
@@ -57,21 +57,31 @@ def parse_sim_and_render_backend(sim_backend: str, render_backend: str) -> Backe
     else:
         raise ValueError(f"Invalid simulation backend: {sim_backend}")
 
-    if platform.system() == "Darwin":
-        render_device = sapien.Device("cpu")
-        render_backend = "sapien_cpu"
-        logger.warning(
-            "Detected MacOS system, forcing render backend to be sapien_cpu and render device to be MacOS compatible."
-        )
-    elif render_backend == "sapien_cuda":
-        render_device = sapien.Device("cuda")
-    elif render_backend == "sapien_cpu":
-        render_device = sapien.Device("cpu")
-    elif render_backend[:4] == "cuda":
-        render_device = sapien.Device(render_backend)
-    else:
-        # handle special cases such as for AMD gpus, render_backend must be defined as pci:... instead as cuda is not available.
-        render_device = sapien.Device(render_backend)
+    try:
+        if platform.system() == "Darwin":
+            render_device = sapien.Device("cpu")
+            render_backend = "sapien_cpu"
+            logger.warning(
+                "Detected MacOS system, forcing render backend to be sapien_cpu and render device to be MacOS compatible."
+            )
+        elif render_backend == "sapien_cuda":
+            render_device = sapien.Device("cuda")
+        elif render_backend == "sapien_cpu":
+            render_device = sapien.Device("cpu")
+        elif render_backend[:4] == "cuda":
+            render_device = sapien.Device(render_backend)
+        else:
+            # handle special cases such as for AMD gpus, render_backend must be defined as pci:... instead as cuda is not available.
+            render_device = sapien.Device(render_backend)
+    except RuntimeError as e:
+        if str(e) == 'failed to find device "cuda"':
+            logger.warning(
+                f'Requested to use render device "{render_backend}", but CUDA device was not found. Falling back to "cpu" device. Rendering might be disabled.'
+            )
+            render_device = sapien.Device("cpu")
+            render_backend = "sapien_cpu"
+        else:
+            raise
     return BackendInfo(
         device=device,
         sim_device=sim_device,

--- a/mani_skill/examples/demo_random_action.py
+++ b/mani_skill/examples/demo_random_action.py
@@ -53,6 +53,8 @@ class Args:
     """Seed(s) for random actions and simulator. Can be a single integer or a list of integers. Default is None (no seeds)"""
 
 def main(args: Args):
+    if args.render_mode == "none":
+        args.render_mode = None
     np.set_printoptions(suppress=True, precision=3)
     verbose = not args.quiet
     if isinstance(args.seed, int):

--- a/mani_skill/utils/building/actor_builder.py
+++ b/mani_skill/utils/building/actor_builder.py
@@ -179,11 +179,12 @@ class ActorBuilder(SAPIENActorBuilder):
         build the raw sapien entity. Modifies original SAPIEN function to accept new procedurally generated render components
         """
         entity = sapien.Entity()
-        if self.visual_records or len(self._procedural_shapes) > 0:
-            render_component = self.build_render_component()
-            for shape in self._procedural_shapes:
-                render_component.attach(shape)
-            entity.add_component(render_component)
+        if self.scene.can_render():
+            if self.visual_records or len(self._procedural_shapes) > 0:
+                render_component = self.build_render_component()
+                for shape in self._procedural_shapes:
+                    render_component.attach(shape)
+                entity.add_component(render_component)
         entity.add_component(self.build_physx_component())
         entity.name = self.name
         return entity

--- a/mani_skill/utils/building/articulation_builder.py
+++ b/mani_skill/utils/building/articulation_builder.py
@@ -78,8 +78,9 @@ class ArticulationBuilder(SapienArticulationBuilder):
             )
 
             entity.add_component(link_component)
-            if b.visual_records:
-                entity.add_component(b.build_render_component())
+            if self.scene.can_render():
+                if b.visual_records:
+                    entity.add_component(b.build_render_component())
             entity.name = b.name
 
             link_component.name = f"{name_prefix}{b.name}"

--- a/mani_skill/utils/building/ground.py
+++ b/mani_skill/utils/building/ground.py
@@ -43,65 +43,79 @@ def build_ground(
         ground.set_scene_idxs([0])
     actor = ground.build_static(name=name)
 
-    # generate a grid of right triangles that form 1x1 meter squares centered at (0, 0, 0)
-    floor_length = floor_width if floor_length is None else floor_length
-    num_verts = (floor_width + 1) * (floor_length + 1)
-    vertices = np.zeros((num_verts, 3))
-    floor_half_width = floor_width / 2
-    floor_half_length = floor_length / 2
-    xrange = np.arange(start=-floor_half_width, stop=floor_half_width + 1)
-    yrange = np.arange(start=-floor_half_length, stop=floor_half_length + 1)
-    xx, yy = np.meshgrid(xrange, yrange)
-    xys = np.stack((yy, xx), axis=2).reshape(-1, 2)
-    vertices[:, 0] = xys[:, 0] + xy_origin[0]
-    vertices[:, 1] = xys[:, 1] + xy_origin[1]
-    vertices[:, 2] = altitude
-    normals = np.zeros((len(vertices), 3))
-    normals[:, 2] = 1
+    if scene.can_render():
+        # generate a grid of right triangles that form 1x1 meter squares centered at (0, 0, 0)
+        floor_length = floor_width if floor_length is None else floor_length
+        num_verts = (floor_width + 1) * (floor_length + 1)
+        vertices = np.zeros((num_verts, 3))
+        floor_half_width = floor_width / 2
+        floor_half_length = floor_length / 2
+        xrange = np.arange(start=-floor_half_width, stop=floor_half_width + 1)
+        yrange = np.arange(start=-floor_half_length, stop=floor_half_length + 1)
+        xx, yy = np.meshgrid(xrange, yrange)
+        xys = np.stack((yy, xx), axis=2).reshape(-1, 2)
+        vertices[:, 0] = xys[:, 0] + xy_origin[0]
+        vertices[:, 1] = xys[:, 1] + xy_origin[1]
+        vertices[:, 2] = altitude
+        normals = np.zeros((len(vertices), 3))
+        normals[:, 2] = 1
 
-    mat = sapien.render.RenderMaterial()
-    mat.base_color_texture = sapien.render.RenderTexture2D(
-        filename=texture_file,
-        mipmap_levels=mipmap_levels,
-    )
-    uv_scale = floor_width / texture_square_len
-    uvs = np.zeros((len(vertices), 2))
-    uvs[:, 0] = (xys[:, 0] * uv_scale + floor_half_width) / floor_width
-    uvs[:, 1] = (xys[:, 1] * uv_scale + floor_half_width) / floor_width
-
-    # TODO: This is fast but still two for loops which is a little annoying
-    triangles = []
-    for i in range(floor_length):
-        triangles.append(
-            np.stack(
-                [
-                    np.arange(floor_width) + i * (floor_width + 1),
-                    np.arange(floor_width) + 1 + floor_width + i * (floor_width + 1),
-                    np.arange(floor_width) + 1 + i * (floor_width + 1),
-                ],
-                axis=1,
-            )
+        mat = sapien.render.RenderMaterial()
+        mat.base_color_texture = sapien.render.RenderTexture2D(
+            filename=texture_file,
+            mipmap_levels=mipmap_levels,
         )
-    for i in range(floor_length):
-        triangles.append(
-            np.stack(
-                [
-                    np.arange(floor_width) + 1 + floor_width + i * (floor_width + 1),
-                    np.arange(floor_width) + floor_width + 2 + i * (floor_width + 1),
-                    np.arange(floor_width) + 1 + i * (floor_width + 1),
-                ],
-                axis=1,
+        uv_scale = floor_width / texture_square_len
+        uvs = np.zeros((len(vertices), 2))
+        uvs[:, 0] = (xys[:, 0] * uv_scale + floor_half_width) / floor_width
+        uvs[:, 1] = (xys[:, 1] * uv_scale + floor_half_width) / floor_width
+
+        # TODO: This is fast but still two for loops which is a little annoying
+        triangles = []
+        for i in range(floor_length):
+            triangles.append(
+                np.stack(
+                    [
+                        np.arange(floor_width) + i * (floor_width + 1),
+                        np.arange(floor_width)
+                        + 1
+                        + floor_width
+                        + i * (floor_width + 1),
+                        np.arange(floor_width) + 1 + i * (floor_width + 1),
+                    ],
+                    axis=1,
+                )
             )
+        for i in range(floor_length):
+            triangles.append(
+                np.stack(
+                    [
+                        np.arange(floor_width)
+                        + 1
+                        + floor_width
+                        + i * (floor_width + 1),
+                        np.arange(floor_width)
+                        + floor_width
+                        + 2
+                        + i * (floor_width + 1),
+                        np.arange(floor_width) + 1 + i * (floor_width + 1),
+                    ],
+                    axis=1,
+                )
+            )
+        triangles = np.concatenate(triangles)
+
+        shape = sapien.render.RenderShapeTriangleMesh(
+            vertices=vertices,
+            triangles=triangles,
+            normals=normals,
+            uvs=uvs,
+            material=mat,
         )
-    triangles = np.concatenate(triangles)
 
-    shape = sapien.render.RenderShapeTriangleMesh(
-        vertices=vertices, triangles=triangles, normals=normals, uvs=uvs, material=mat
-    )
-
-    for obj in actor._objs:
-        floor_comp = sapien.render.RenderBodyComponent()
-        floor_comp.attach(shape)
-        obj.add_component(floor_comp)
+        for obj in actor._objs:
+            floor_comp = sapien.render.RenderBodyComponent()
+            floor_comp.attach(shape)
+            obj.add_component(floor_comp)
 
     return actor

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -41,14 +41,14 @@ class TableSceneBuilder(SceneBuilder):
             p=[-0.12, 0, -0.9196429], q=euler2quat(0, 0, np.pi / 2)
         )
         table = builder.build_kinematic(name="table-workspace")
-        aabb = (
-            table._objs[0]
-            .find_component_by_type(sapien.render.RenderBodyComponent)
-            .compute_global_aabb_tight()
-        )
-        self.table_length = aabb[1, 0] - aabb[0, 0]
-        self.table_width = aabb[1, 1] - aabb[0, 1]
-        self.table_height = aabb[1, 2] - aabb[0, 2]
+        # aabb = (
+        #     table._objs[0]
+        #     .find_component_by_type(sapien.render.RenderBodyComponent)
+        #     .compute_global_aabb_tight()
+        # )
+        self.table_length = 1
+        self.table_width = 1
+        self.table_height = 1
         floor_width = 100
         if self.scene.parallel_in_single_scene:
             floor_width = 500

--- a/mani_skill/utils/scene_builder/table/scene_builder.py
+++ b/mani_skill/utils/scene_builder/table/scene_builder.py
@@ -46,9 +46,16 @@ class TableSceneBuilder(SceneBuilder):
         #     .find_component_by_type(sapien.render.RenderBodyComponent)
         #     .compute_global_aabb_tight()
         # )
-        self.table_length = 1
-        self.table_width = 1
-        self.table_height = 1
+        # value of the call above is saved below
+        aabb = np.array(
+            [
+                [-0.7402168, -1.2148621, -0.91964257],
+                [0.4688596, 1.2030163, 3.5762787e-07],
+            ]
+        )
+        self.table_length = aabb[1, 0] - aabb[0, 0]
+        self.table_width = aabb[1, 1] - aabb[0, 1]
+        self.table_height = aabb[1, 2] - aabb[0, 2]
         floor_width = 100
         if self.scene.parallel_in_single_scene:
             floor_width = 500


### PR DESCRIPTION
Closes #1129 and #502 

- Can specify render_backend="cpu" which usually will just disable rendering all together. If no cuda devices are available you can now just run CPU simulation only. Warnings are given if there is an attempt to render when rendering is disabled. if cuda is available with cpu rendering backend you can just do GPU sim only without any rendering
- env.scene.can_render now returns a bool indicating whether or not rendering is possible with the environment
- table scene builder now uses pre-computed AABB values to determine placement  and size instead of using the visual mesh which uses the render system for the convenient API to compute aabb.