### PR TITLE
vectorenv: relax env type annotation to gymnasium.Env

### DIFF
--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -10,6 +10,7 @@ from mani_skill.utils.common import torch_clone_dict
 from mani_skill.utils.structs.types import Array
 
 if TYPE_CHECKING:
+    from gymnasium import Env
     from mani_skill.envs.sapien_env import BaseEnv
 
 
@@ -35,7 +36,7 @@ class ManiSkillVectorEnv(VectorEnv):
 
     def __init__(
         self,
-        env: Union[BaseEnv, str],
+        env: Union[Env, str],
         num_envs: int = None,
         auto_reset: bool = True,
         ignore_terminations: bool = False,


### PR DESCRIPTION
<blockquote>
<p><strong>Changes at a glance</strong></p>
<ul>
<li>
<p>Relax the type annotation of <code inline="">ManiSkillVectorEnv.__init__</code> from <code inline="">Union[BaseEnv, str]</code> to <code inline="">Union[gymnasium.Env, str]</code>.</p>
</li>
<li>
<p>No functional behavior is changed; this is purely a typing-quality improvement.</p>
</li>
</ul>
</blockquote>
<h3>Motivation</h3>
<p>Static type checkers such as <strong>mypy</strong> or IDEs like <strong>PyCharm</strong> currently raise false-positive warnings when users pass a <code inline="">gym.Wrapper</code> (or any class that implements the standard Gym API but does <strong>not</strong> subclass <code inline="">BaseEnv</code>) to <code inline="">ManiSkillVectorEnv</code>.<br>
See detailed discussion in <strong>Issue #1105</strong>—this PR implements the one-line diff proposed there to make the API better reflect ManiSkill’s “duck-typing” philosophy.</p>



<p><strong>Runtime logic is unaffected</strong>: the wrapper still obtains the underlying <code inline="">BaseEnv</code> via <code inline="">.unwrapped</code>, so downstream code behaves exactly as before.</p>
<h3>Backward compatibility</h3>
<ul>
<li>
<p><code inline="">BaseEnv</code> → <code inline="">Env</code> is a strict superset: every <code inline="">BaseEnv</code> <strong>is</strong> an <code inline="">Env</code>, so existing user code requires <strong>no</strong> changes.</p>
</li>
</ul>

<h3>Related issue</h3>
<p>Closes #1105</p>