### PR TITLE
[BugFix] Unified get / set controller state function across multi agent and base agent, fix some issues with recording trajectories

### DIFF
--- a/mani_skill/agents/base_agent.py
+++ b/mani_skill/agents/base_agent.py
@@ -340,6 +340,18 @@ class BaseAgent:
             obs.update(controller=controller_state)
         return obs
 
+    def get_controller_state(self):
+        """
+        Get the state of the controller.
+        """
+        return self.controller.get_state()
+
+    def set_controller_state(self, state: Array):
+        """
+        Set the state of the controller.
+        """
+        self.controller.set_state(state)
+
     def get_state(self) -> Dict:
         """Get current state, including robot state and controller state"""
         state = dict()
@@ -353,7 +365,7 @@ class BaseAgent:
         state["robot_qvel"] = self.robot.get_qvel()
 
         # controller state
-        state["controller"] = self.controller.get_state()
+        state["controller"] = self.get_controller_state()
 
         return state
 
@@ -368,7 +380,7 @@ class BaseAgent:
         self.robot.set_qvel(state["robot_qvel"])
 
         if not ignore_controller and "controller" in state:
-            self.controller.set_state(state["controller"])
+            self.set_controller_state(state["controller"])
         if self.device.type == "cuda":
             self.scene._gpu_apply_all()
             self.scene.px.gpu_update_articulation_kinematics()

--- a/mani_skill/agents/multi_agent.py
+++ b/mani_skill/agents/multi_agent.py
@@ -70,6 +70,18 @@ class MultiAgent(BaseAgent, Generic[T]):
         for agent in self.agents:
             agent.controller.before_simulation_step()
 
+    def get_controller_state(self):
+        """
+        Get the state of the controller.
+        """
+        return {
+            uid: agent.get_controller_state() for uid, agent in self.agents_dict.items()
+        }
+
+    def set_controller_state(self, state: Dict):
+        for uid, agent in self.agents_dict.items():
+            agent.set_controller_state(state[uid])
+
     # -------------------------------------------------------------------------- #
     # Other
     # -------------------------------------------------------------------------- #

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1243,7 +1243,8 @@ class BaseEnv(gym.Env):
         sim_state = self.scene.get_sim_state()
         controller_state = self.agent.get_controller_state()
         # Remove any empty keys from controller_state
-        controller_state = {k: v for k, v in controller_state.items() if v}
+        if isinstance(self.agent.controller, dict):
+            controller_state = {k: v for k, v in controller_state.items() if len(v) > 0}
         if len(controller_state) > 0:
             sim_state["controller"] = controller_state
         return sim_state

--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1241,7 +1241,9 @@ class BaseEnv(gym.Env):
         Get environment state dictionary. Override to include task information (e.g., goal)
         """
         sim_state = self.scene.get_sim_state()
-        controller_state = self.agent.controller.get_state()
+        controller_state = self.agent.get_controller_state()
+        # Remove any empty keys from controller_state
+        controller_state = {k: v for k, v in controller_state.items() if v}
         if len(controller_state) > 0:
             sim_state["controller"] = controller_state
         return sim_state

--- a/mani_skill/envs/tasks/tabletop/plug_charger.py
+++ b/mani_skill/envs/tasks/tabletop/plug_charger.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 import numpy as np
 import sapien
@@ -42,6 +42,7 @@ class PlugChargerEnv(BaseEnv):
 
     SUPPORTED_ROBOTS = ["panda_wristcam"]
     agent: Union[PandaWristCam]
+    SUPPORTED_REWARD_MODES = ["none", "sparse"]
 
     def __init__(
         self, *args, robot_uids="panda_wristcam", robot_init_qpos_noise=0.02, **kwargs
@@ -199,7 +200,10 @@ class PlugChargerEnv(BaseEnv):
                 )
                 qpos = (
                     torch.normal(
-                        0, self.robot_init_qpos_noise, (b, len(qpos)), device=self.device
+                        0,
+                        self.robot_init_qpos_noise,
+                        (b, len(qpos)),
+                        device=self.device,
                     )
                     + qpos
                 )

--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -27,6 +27,7 @@ from mani_skill.trajectory.merge_trajectory import merge_trajectories
 from mani_skill.trajectory.utils.actions import conversion as action_conversion
 from mani_skill.utils import common, io_utils, wrappers
 from mani_skill.utils.logging_utils import logger
+from mani_skill.utils.wrappers.flatten import FlattenActionSpaceWrapper
 from mani_skill.utils.wrappers.record import RecordEpisode
 
 
@@ -399,6 +400,11 @@ def _main(
     json_path = traj_path.replace(".h5", ".json")
     json_data = io_utils.load_json(json_path)
     env = gym.make(env_id, **env_kwargs)
+    if isinstance(env.action_space, gym.spaces.Dict):
+        logger.warning(
+            "We currently do not track which wrappers are used when recording trajectories but majority of the time in multi-agent envs with dictionary action spaces the actions are stored as flat vectors. We will flatten the action space with the ManiSkill provided FlattenActionSpaceWrapper. If you do not want this behavior you can copy the replay trajectory code yourself and modify it as needed."
+        )
+        env = FlattenActionSpaceWrapper(env)
     # TODO (support adding wrappers to the recorded data?)
 
     # if pbar is not None:


### PR DESCRIPTION
Partly closes #1043 and #776 by default applying action space flattening wrapper when replaying trajectories in an environment with a dict action space (the multi-agent environments). A warning is provided always to the user to let them know that we are doing this implicit behavior and if its not wanted they should copy the code and modify.

Further fixes bug with record controller states in multi-agent settings

The following script can be used to verify it works now
```
python -m mani_skill.trajectory.replay_trajectory --traj-path ~/.maniskill/demos/TwoRobotPickCube-v1/rl/trajectory.none.pd_joint_delta_pos.cuda.h5 -n 1 -b physx_cuda --vis --use-first-env-state
```
