### PR TITLE
[Feature] support more flexible link merging and update docs

### DIFF
--- a/docs/source/user_guide/tutorials/custom_tasks/advanced.md
+++ b/docs/source/user_guide/tutorials/custom_tasks/advanced.md
@@ -76,7 +76,7 @@ class MyCustomTask(BaseEnv):
         # etc.
 ```
 
-Properties that exist regardless of geometry like object pose can be easily fetched after merging actors. This enables simple diverse simulation of diverse objects/geometries.
+Properties that exist regardless of geometry like object pose can be easily fetched after merging actors. This enables simple diverse simulation of diverse objects/geometries. Furthermore the `Actor.merge` function is fairly flexible, you do not necessarily need to ensure there the number of actors merged is equal to or even divisible by the number of parallel environments (stored in `self.num_envs`). Merge operations are simply a way to view batched data across different link objects via a single object.
 
 ### Merging Articulations
 
@@ -101,7 +101,7 @@ Properties that exist regardless of articulation include the base link's data (e
 
 ### Merging Links
 
-Similar to Actors, you can also merge any list of links sourced from any articulations you create. Upon merging, ManiSkill will also create a merged joint object that gives easy access to qpos values of links/joints you need without having to mess with complex indexing of padded data.
+Similar to Actors, you can also merge any list of links sourced from any articulations you create. Upon merging, ManiSkill will also create a merged joint object that gives easy access to data of the the parent joints of each link without having to work with complex indexing of padded data. The joint merged object is only available if every link merged is not a root link as root links do not have a parent joint. Furthermore the `Link.merge` function is fairly flexible, you do not necessarily need to ensure there the number of links merged is equal to or even divisible by the number of parallel environments (stored in `self.num_envs`). Merge operations are simply a way to view batched data across different link objects via a single object.
 
 
 ```python

--- a/mani_skill/utils/structs/link.py
+++ b/mani_skill/utils/structs/link.py
@@ -81,30 +81,23 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
         merged_joint_indexes = []
         merged_active_joint_indexes = []
         articulation_objs = []
-        is_root = links[0].is_root
+        has_one_root_link = any(link.is_root.any() for link in links)
         merged_scene_idxs = []
-        num_objs_per_actor = links[0]._num_objs
         for link in links:
             objs += link._objs
-            assert (
-                link.is_root == is_root
-            ), "all links given to merge must all be root or all not be root links"
             merged_scene_idxs.append(link._scene_idxs)
-            # if link is not root, then there are joints we can merge automatically
-            if not is_root:
+            # if all links are not root links, then there are joints we can merge automatically
+            if not has_one_root_link:
                 joint_objs += link.joint._objs
                 articulation_objs += link.articulation._objs
 
                 merged_active_joint_indexes.append(link.joint.active_index)
                 merged_joint_indexes.append(link.joint.index)
-            assert (
-                link._num_objs == num_objs_per_actor
-            ), "Each given link must have the same number of managed objects"
         merged_scene_idxs = torch.concat(merged_scene_idxs)
         merged_link = Link.create(
             objs, scene=links[0].scene, scene_idxs=merged_scene_idxs
         )
-        if not is_root:
+        if not has_one_root_link:
             merged_active_joint_indexes = torch.concat(merged_active_joint_indexes)
             merged_joint_indexes = torch.concat(merged_joint_indexes)
             merged_joint = ArticulationJoint.create(
@@ -116,9 +109,10 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
                 active_joint_index=merged_active_joint_indexes,
             )
             merged_link.joint = merged_joint
+            if name is not None:
+                merged_joint.name = f"{name}_joints"
             merged_joint.child_link = merged_link
         # remove articulation reference as it does not make sense and is only used to instantiate some properties like the physx system
-        # TODO (stao): akin to the joint merging above, we can also make a view of the articulations of each link. Is it necessary?
         merged_link.articulation = None
         merged_link.name = name
         merged_link.merged = True


### PR DESCRIPTION
Closes #1188 

- Further now adds a default name to the merged joint if the merged links are given a name, equal to f"{link_name}_joints"
- Removes old assertions about link roots and having the same number of objects