### PR TITLE
[BugFix] fix joint set/get of drive position/velocity targets

### DIFF
--- a/mani_skill/envs/tasks/tabletop/pick_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pick_cube.py
@@ -129,8 +129,6 @@ class PickCubeEnv(BaseEnv):
             goal_xyz[:, 1] += self.cube_spawn_center[1]
             goal_xyz[:, 2] = torch.rand((b)) * self.max_goal_height + xyz[:, 2]
             self.goal_site.set_pose(Pose.create_from_pq(goal_xyz))
-            self.agent.robot.links[2].joint.set_drive_target(torch.zeros(b))
-            print(self.agent.robot.links[2].joint.drive_target)
 
     def _get_obs_extra(self, info: Dict):
         # in reality some people hack is_grasped into observations by checking if the gripper can close fully or not

--- a/mani_skill/envs/tasks/tabletop/pick_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pick_cube.py
@@ -129,6 +129,8 @@ class PickCubeEnv(BaseEnv):
             goal_xyz[:, 1] += self.cube_spawn_center[1]
             goal_xyz[:, 2] = torch.rand((b)) * self.max_goal_height + xyz[:, 2]
             self.goal_site.set_pose(Pose.create_from_pq(goal_xyz))
+            self.agent.robot.links[2].joint.set_drive_target(torch.zeros(b))
+            print(self.agent.robot.links[2].joint.drive_target)
 
     def _get_obs_extra(self, info: Dict):
         # in reality some people hack is_grasped into observations by checking if the gripper can close fully or not

--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import sapien
@@ -496,10 +496,30 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         """
         return self.get_net_contact_impulses(link_names) / self.scene.timestep
 
-    def get_joint_target_indices(self, joint_indices):
+    def get_joint_target_indices(
+        self, joint_indices: Union[Array, List[int], List[ArticulationJoint]]
+    ):
+        """
+        Gets the meshgrid indexes for indexing px.cuda_articulation_target_* values given a 1D list of joint indexes or a 1D list of ArticulationJoint objects.
+
+        Internally the given input is made to a tuple for a cache key and is used to cache results for fast lookup in the future, particularly for large-scale GPU simulations.
+        """
+        if isinstance(joint_indices, list):
+            joint_indices = tuple(joint_indices)
         if joint_indices not in self._cached_joint_target_indices:
+            vals = joint_indices
+            if isinstance(joint_indices[0], ArticulationJoint):
+                for joint in joint_indices:
+                    assert (
+                        joint.articulation == self
+                    ), "Can only fetch this articulation's joint_target_indices when provided joints from this articulation"
+                vals = [
+                    x.active_index[0] for x in joint_indices
+                ]  # active_index on joint is batched but it should be the same value across all managed joint objects
             self._cached_joint_target_indices[joint_indices] = torch.meshgrid(
-                self._data_index, joint_indices, indexing="ij"
+                self._data_index,
+                common.to_tensor(vals, device=self.device),
+                indexing="ij",
             )
         return self._cached_joint_target_indices[joint_indices]
 
@@ -516,7 +536,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         of shape (N, M) where N is the number of environments and M is the number of active joints.
         """
         if self.scene.gpu_sim_enabled:
-            return self.px.cuda_articulation_target_qpos[
+            return self.px.cuda_articulation_target_qpos.torch()[
                 self.get_joint_target_indices(self.active_joints)
             ]
         else:
@@ -529,7 +549,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
         of shape (N, M) where N is the number of environments and M is the number of active joints.
         """
         if self.scene.gpu_sim_enabled:
-            return self.px.cuda_articulation_target_qvel[
+            return self.px.cuda_articulation_target_qvel.torch()[
                 self.get_joint_target_indices(self.active_joints)
             ]
         else:
@@ -853,15 +873,20 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
     def set_joint_drive_targets(
         self,
         targets: Array,
-        joints: List[ArticulationJoint] = None,
-        joint_indices: torch.Tensor = None,
+        joints: Optional[List[ArticulationJoint]] = None,
+        joint_indices: Optional[torch.Tensor] = None,
     ):
         """
-        Set drive targets on active joints. Joint indices are required to be given for GPU sim, and joint objects are required for the CPU sim
+        Set drive targets on active joints given joints. For GPU simulation only joint_indices argument is supported, which should be a 1D list of the active joint indices in the articulation.
+
+        joints argument will always be used when possible and is the recommended approach. On CPU simulation the joints argument is required, joint_indices is not supported.
         """
         if self.scene.gpu_sim_enabled:
             targets = common.to_tensor(targets, device=self.device)
-            gx, gy = self.get_joint_target_indices(joint_indices)
+            if joints is not None:
+                gx, gy = self.get_joint_target_indices(joints)
+            else:
+                gx, gy = self.get_joint_target_indices(joint_indices)
             self.px.cuda_articulation_target_qpos.torch()[
                 gx[self.scene._reset_mask], gy[self.scene._reset_mask]
             ] = targets

--- a/mani_skill/utils/structs/articulation_joint.py
+++ b/mani_skill/utils/structs/articulation_joint.py
@@ -240,18 +240,25 @@ class ArticulationJoint(BaseStruct[physx.PhysxArticulationJoint]):
 
     @property
     def drive_target(self) -> torch.Tensor:
+        assert (
+            self.active_index is not None
+        ), "Cannot get drive position targets of inactive joints"
         if self.scene.gpu_sim_enabled:
-            raise NotImplementedError(
-                "Getting drive targets of individual joints is not implemented yet."
-            )
+            return self.articulation.px.cuda_articulation_target_qpos.torch()[
+                self._data_index,
+                self.active_index,
+            ]
         else:
             return torch.from_numpy(self._objs[0].drive_target[None, :])
 
     @drive_target.setter
     def drive_target(self, arg1: Array) -> None:
         arg1 = common.to_tensor(arg1, device=self.device)
+        assert (
+            self.active_index is not None
+        ), "Cannot set drive position targets of inactive joints"
         if self.scene.gpu_sim_enabled:
-            self.articulation.px.cuda_articulation_target_qpos[
+            self.articulation.px.cuda_articulation_target_qpos.torch()[
                 self._data_index[self.scene._reset_mask[self._scene_idxs]],
                 self.active_index,
             ] = arg1
@@ -264,20 +271,28 @@ class ArticulationJoint(BaseStruct[physx.PhysxArticulationJoint]):
 
     @property
     def drive_velocity_target(self) -> torch.Tensor:
+        assert (
+            self.active_index is not None
+        ), "Cannot get drive velocity targets of inactive joints"
         if self.scene.gpu_sim_enabled:
-            raise NotImplementedError(
-                "Cannot read drive velocity targets at the moment in GPU simulation"
-            )
+            return self.articulation.px.cuda_articulation_target_qvel.torch()[
+                self._data_index,
+                self.active_index,
+            ]
         else:
             return torch.from_numpy(self._objs[0].drive_velocity_target[None, :])
 
     @drive_velocity_target.setter
     def drive_velocity_target(self, arg1: Array) -> None:
         arg1 = common.to_tensor(arg1, device=self.device)
+        assert (
+            self.active_index is not None
+        ), "Cannot set drive velocity targets of inactive joints"
         if self.scene.gpu_sim_enabled:
-            raise NotImplementedError(
-                "Cannot set drive velocity targets at the moment in GPU simulation"
-            )
+            self.articulation.px.cuda_articulation_target_qvel.torch()[
+                self._data_index[self.scene._reset_mask[self._scene_idxs]],
+                self.active_index,
+            ] = arg1
         else:
             if arg1.shape == ():
                 arg1 = arg1.reshape(


### PR DESCRIPTION
Closes #1187 
- adds missing .torch() calls before indexing to go from sapien cuda array to torch for ArticulationJoint class
- adds missing .torch() calls for the same issue as above but in the Articulation class
- adds support to read and set joint velocity targets
- adds assert statements for set/getters of joint target functions to tell users if they are trying to work with a joint that is not active (and thus has no meaningful drive target)
- Articulation set_drive_targets function (position and velocity) no longer require joint_indices as an argument for GPU sim, it now handles (and is recommended) a list of ArticulationJoint objects (all of which must be from the same articulation).