### PR TITLE
Add mimic dictionary for xarm6_robotiq

### DIFF
--- a/mani_skill/agents/robots/xarm6/xarm6_robotiq.py
+++ b/mani_skill/agents/robots/xarm6/xarm6_robotiq.py
@@ -214,7 +214,7 @@ class XArm6Robotiq(BaseAgent):
         # -------------------------------------------------------------------------- #
 
         # Define a passive controller config to simply "turn off" other joints from being controlled and set their properties (damping/friction) to 0.
-        # These joints are controlled passively by the mimic controller later on.
+        # These joints are not explicitly controlled, and are free to move as per surrounding forces.
         passive_finger_joint_names = [
             "left_inner_knuckle_joint",
             "right_inner_knuckle_joint",
@@ -231,6 +231,9 @@ class XArm6Robotiq(BaseAgent):
         finger_joint_names = ["left_outer_knuckle_joint", "right_outer_knuckle_joint"]
 
         # Use a mimic controller config to define one action to control both fingers
+        mimic_config = dict(
+            left_outer_knuckle_joint=dict(joint="right_outer_knuckle_joint", multiplier=1.0, offset=0.0),
+        )
         finger_mimic_pd_joint_pos = PDJointPosMimicControllerConfig(
             finger_joint_names,
             lower=None,
@@ -240,6 +243,7 @@ class XArm6Robotiq(BaseAgent):
             force_limit=self.gripper_force_limit,
             friction=self.gripper_friction,
             normalize_action=False,
+            mimic=mimic_config,
         )
 
         finger_mimic_pd_joint_delta_pos = PDJointPosMimicControllerConfig(
@@ -252,6 +256,7 @@ class XArm6Robotiq(BaseAgent):
             friction=self.gripper_friction,
             normalize_action=True,
             use_delta=True,
+            mimic=mimic_config,
         )
 
         controller_configs = dict(


### PR DESCRIPTION
Add a mimic dictionary for xarm6_robotiq to explicitly define which joints are the mimic joints (controlled by agent), and which are control joints (controlled by mimic joint). 
This is done to support the advanced mimic configurations introduced in #981, and stop mimic warnings for xarm6_robotiq.