### PR TITLE
Fix #1145: Remove unused class attribute cube_half_size

### DIFF
--- a/mani_skill/envs/tasks/tabletop/pick_cube.py
+++ b/mani_skill/envs/tasks/tabletop/pick_cube.py
@@ -42,7 +42,6 @@ class PickCubeEnv(BaseEnv):
         "widowxai",
     ]
     agent: Union[Panda, Fetch, XArm6Robotiq, SO100, WidowXAI]
-    cube_half_size = 0.02
     goal_thresh = 0.025
     cube_spawn_half_size = 0.05
     cube_spawn_center = (0, 0)


### PR DESCRIPTION
Closes #1145

This PR removes the unused `cube_half_size` class attribute from `PickCubeEnv` as discussed in the issue.

This is a pure code cleanup and should have no functional impact.