### PR TITLE
[Bug Fix] Fixed bug that caused drop in TDMPC2 evaluation performance

### DIFF
--- a/examples/baselines/tdmpc2/README.md
+++ b/examples/baselines/tdmpc2/README.md
@@ -47,9 +47,9 @@ python evaluate.py model_size=5 seed=1 exp_name=default \
   save_video_local=true checkpoint=/absolute/path/to/checkpoint.pt
 ```
 
-* Make sure you specify the same control_mode the model was trained on if it's not default.
+* **Make sure you specify the same `num_eval_envs` and `control_mode` the model was trained on if it's not default.**
 * The video are saved under ```logs/{env_id}/{seed}/{exp_name}/videos```
-* The number of video saved is determined by ```num_envs * eval_episodes_per_env```
+* The number of video saved is determined by ```num_eval_envs * eval_episodes_per_env```
 
 ## Some Notes
 


### PR DESCRIPTION
Resolved issue presented in #1221. The tdmpc2 agent expects `num_eval_envs` to be consistent with what's set in training (previously, I had it hard-coded to 1 for simplicity of video recording). For some reason, the previous implementation worked fine with the `pd_ee_delta_pose` controller but had troubles with the `pd_ee_delta_pos` controller.