### PR TITLE
[BugFix] Fix setters for root linear and angular velocities

### DIFF
--- a/mani_skill/utils/structs/articulation.py
+++ b/mani_skill/utils/structs/articulation.py
@@ -824,7 +824,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
             arg1 = common.to_tensor(arg1, device=self.device)
             self.px.cuda_rigid_body_data.torch()[
                 self.root._body_data_index[self.scene._reset_mask[self._scene_idxs]],
-                7:10,
+                10:13,
             ] = arg1
         else:
             arg1 = common.to_numpy(arg1)
@@ -842,7 +842,7 @@ class Articulation(BaseStruct[physx.PhysxArticulation]):
             arg1 = common.to_tensor(arg1, device=self.device)
             self.px.cuda_rigid_body_data.torch()[
                 self.root._body_data_index[self.scene._reset_mask[self._scene_idxs]],
-                10:13,
+                7:10,
             ] = arg1
         else:
             arg1 = common.to_numpy(arg1)


### PR DESCRIPTION
Hello,

Using the latest Maniskill commit from the main branch, I just noticed that `self.agent.robot.set_root_linear_velocity(xxx)` actually sets the root angular velocity, and `self.agent.robot.set_root_angular_velocity(xxx)` sets the linear one.

This can be reproduced by putting the following code in one of the mobile robot environment, like humanoid_stand.py
```
lin = torch.zeros((self.num_envs, 3), dtype=torch.float, device=self.device, requires_grad=False)
lin[:, 2] = +10.0
ang = torch.zeros((self.num_envs, 3), dtype=torch.float, device=self.device, requires_grad=False)
ang[:, 2] = -5.0

self.agent.robot.set_root_linear_velocity(lin)
self.agent.robot.set_root_angular_velocity(ang)

if self.gpu_sim_enabled:
    self.scene._gpu_apply_all()
    self.scene._gpu_fetch_all()

print(self.agent.robot.get_root_linear_velocity()[0])
print(self.agent.robot.get_root_angular_velocity()[0])
```
This results in:
```
tensor([0., 0., -5.], device='cuda:0')
tensor([0., 0., 10.], device='cuda:0')
```

Or more directly,
```
vec = torch.zeros((self.num_envs, 3), dtype=torch.float, device=self.device, requires_grad=False)
vec[:, 2] = +10.0

self.agent.robot.set_root_angular_velocity(vec)

if self.gpu_sim_enabled:
    self.scene._gpu_apply_all()
    self.scene._gpu_fetch_all()
```
launches the robot into the sky, while `set_root_linear_velocity` makes it spin.