### PR TITLE
[Docs] Tasks mistakenly documented as supporting MotionPlanning

### DIFF
--- a/docs/source/tasks/table_top_gripper/index.md
+++ b/docs/source/tasks/table_top_gripper/index.md
@@ -93,7 +93,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PlaceSphere-v1_rt_thumb_first.png' alt='PlaceSphere-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PlaceSphere-v1_rt_thumb_last.png' alt='PlaceSphere-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>❌</p></td>
+<td><p>✅</p></td>
 <td><p>50</p></td>
 </tr>
 <tr class="row-odd">

--- a/docs/source/tasks/table_top_gripper/index.md
+++ b/docs/source/tasks/table_top_gripper/index.md
@@ -109,7 +109,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PokeCube-v1_rt_thumb_first.png' alt='PokeCube-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PokeCube-v1_rt_thumb_last.png' alt='PokeCube-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>✅</p></td>
+<td><p>❌</p></td>
 <td><p>50</p></td>
 </tr>
 <tr class="row-odd">
@@ -141,7 +141,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PushT-v1_rt_thumb_first.png' alt='PushT-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/PushT-v1_rt_thumb_last.png' alt='PushT-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>✅</p></td>
+<td><p>❌</p></td>
 <td><p>100</p></td>
 </tr>
 <tr class="row-odd">
@@ -149,7 +149,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/RollBall-v1_rt_thumb_first.png' alt='RollBall-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/RollBall-v1_rt_thumb_last.png' alt='RollBall-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>✅</p></td>
+<td><p>❌</p></td>
 <td><p>80</p></td>
 </tr>
 <tr class="row-odd">
@@ -182,7 +182,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/TwoRobotPickCube-v1_rt_thumb_first.png' alt='TwoRobotPickCube-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/TwoRobotPickCube-v1_rt_thumb_last.png' alt='TwoRobotPickCube-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>✅</p></td>
+<td><p>❌</p></td>
 <td><p>100</p></td>
 </tr>
 <tr class="row-odd">
@@ -190,7 +190,7 @@ Table of all tasks/environments in this category. Task column is the environment
 <td><div style='display:flex;gap:4px;align-items:center'><img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/TwoRobotStackCube-v1_rt_thumb_first.png' alt='TwoRobotStackCube-v1'> <img style='min-width:min(50%, 100px);max-width:100px;height:auto' src='../../_static/env_thumbnails/TwoRobotStackCube-v1_rt_thumb_last.png' alt='TwoRobotStackCube-v1'></div></td>
 <td><p>✅</p></td>
 <td><p>✅</p></td>
-<td><p>✅</p></td>
+<td><p>❌</p></td>
 <td><p>100</p></td>
 </tr>
 </tbody>


### PR DESCRIPTION
### Description  
Fix an inconsistency in [the documentation](https://maniskill.readthedocs.io/en/latest/tasks/table_top_gripper/index.html) where tasks were featured as having motion planning support, even though they are not listed in the [motionplanning task dictionary](https://github.com/haosulab/ManiSkill/blob/main/mani_skill/examples/motionplanning/panda/run.py).  
