### PR TITLE
[Docs] Licensing

### DIFF
--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -1,0 +1,32 @@
+Pytorch3D license ( https://github.com/facebookresearch/pytorch3d/ ):
+
+BSD License
+
+For PyTorch3D software
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Meta nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mani_skill/utils/geometry/bounding_cylinder.py
+++ b/mani_skill/utils/geometry/bounding_cylinder.py
@@ -1,137 +1,161 @@
-#
-# Smallest enclosing circle - Library (Python)
-#
-# Copyright (c) 2020 Project Nayuki
-# https://www.nayuki.io/page/smallest-enclosing-circle
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program (see COPYING.txt and COPYING.LESSER.txt).
-# If not, see <http://www.gnu.org/licenses/>.
-#
+"""
+Smallest enclosing cylinder computation.
 
-# fmt: off
-# isort: skip_file
-import math, random
+Based on the algorithm from:
+https://www.nayuki.io/page/smallest-enclosing-circle
+"""
+
+import math
+from typing import List, Optional, Tuple
+
 import numpy as np
 
 
-# Data conventions: A point is a pair of floats (x, y). A circle is a triple of floats (center x, center y, radius).
+def _compute_smallest_circle(
+    points: List[Tuple[float, float]]
+) -> Optional[Tuple[float, float, float]]:
+    points = [(float(x), float(y)) for x, y in points]
+    np.random.shuffle(points)
 
-# Returns the smallest circle that encloses all the given points. Runs in expected O(n) time, randomized.
-# Input: A sequence of pairs of floats or ints, e.g. [(0,5), (3.1,-2.7)].
-# Output: A triple of floats representing a circle.
-# Note: If 0 points are given, None is returned. If 1 point is given, a circle of radius 0 is returned.
-#
-# Initially: No boundary points known
-def make_circle(points):
-    # Convert to float and randomize order
-    shuffled = [(float(x), float(y)) for (x, y) in points]
-    random.shuffle(shuffled)
-
-    # Progressively add points to circle or recompute circle
-    c = None
-    for (i, p) in enumerate(shuffled):
-        if c is None or not is_in_circle(c, p):
-            c = _make_circle_one_point(shuffled[ : i + 1], p)
-    return c
+    circle = None
+    for i, point in enumerate(points):
+        if circle is None or not _point_in_circle(circle, point):
+            circle = _compute_circle_with_point(points[: i + 1], point)
+    return circle
 
 
-# One boundary point known
-def _make_circle_one_point(points, p):
-    c = (p[0], p[1], 0.0)
-    for (i, q) in enumerate(points):
-        if not is_in_circle(c, q):
-            if c[2] == 0.0:
-                c = make_diameter(p, q)
+def _compute_circle_with_point(
+    points: List[Tuple[float, float]], p: Tuple[float, float]
+) -> Tuple[float, float, float]:
+    circle = (p[0], p[1], 0.0)
+    for i, q in enumerate(points):
+        if not _point_in_circle(circle, q):
+            if circle[2] == 0.0:
+                circle = _get_circle_from_diameter(p, q)
             else:
-                c = _make_circle_two_points(points[ : i + 1], p, q)
-    return c
+                circle = _compute_circle_with_two_points(points[: i + 1], p, q)
+    return circle
 
 
-# Two boundary points known
-def _make_circle_two_points(points, p, q):
-    circ = make_diameter(p, q)
-    left  = None
-    right = None
-    px, py = p
-    qx, qy = q
+def _compute_circle_with_two_points(
+    points: List[Tuple[float, float]], p: Tuple[float, float], q: Tuple[float, float]
+) -> Tuple[float, float, float]:
+    circle = _get_circle_from_diameter(p, q)
+    left = right = None
 
-    # For each point not in the two-point circle
     for r in points:
-        if is_in_circle(circ, r):
+        if _point_in_circle(circle, r):
             continue
 
-        # Form a circumcircle and classify it on left or right side
-        cross = _cross_product(px, py, qx, qy, r[0], r[1])
-        c = make_circumcircle(p, q, r)
-        if c is None:
-            continue
-        elif cross > 0.0 and (left is None or _cross_product(px, py, qx, qy, c[0], c[1]) > _cross_product(px, py, qx, qy, left[0], left[1])):
-            left = c
-        elif cross < 0.0 and (right is None or _cross_product(px, py, qx, qy, c[0], c[1]) < _cross_product(px, py, qx, qy, right[0], right[1])):
-            right = c
+        cross = _compute_cross_product(p[0], p[1], q[0], q[1], r[0], r[1])
+        candidate = _compute_circumcircle(p, q, r)
 
-    # Select which circle to return
+        if candidate is None:
+            continue
+        elif cross > 0 and (
+            left is None
+            or _compute_cross_product(
+                p[0], p[1], q[0], q[1], candidate[0], candidate[1]
+            )
+            > _compute_cross_product(p[0], p[1], q[0], q[1], left[0], left[1])
+        ):
+            left = candidate
+        elif cross < 0 and (
+            right is None
+            or _compute_cross_product(
+                p[0], p[1], q[0], q[1], candidate[0], candidate[1]
+            )
+            < _compute_cross_product(p[0], p[1], q[0], q[1], right[0], right[1])
+        ):
+            right = candidate
+
     if left is None and right is None:
-        return circ
+        return circle
     elif left is None:
         return right
     elif right is None:
         return left
     else:
-        return left if (left[2] <= right[2]) else right
+        return left if left[2] <= right[2] else right
 
 
-def make_diameter(a, b):
-    cx = (a[0] + b[0]) / 2
-    cy = (a[1] + b[1]) / 2
-    r0 = math.hypot(cx - a[0], cy - a[1])
-    r1 = math.hypot(cx - b[0], cy - b[1])
-    return (cx, cy, max(r0, r1))
+def _get_circle_from_diameter(
+    a: Tuple[float, float], b: Tuple[float, float]
+) -> Tuple[float, float, float]:
+    center_x = (a[0] + b[0]) / 2
+    center_y = (a[1] + b[1]) / 2
+    radius = max(
+        math.hypot(center_x - a[0], center_y - a[1]),
+        math.hypot(center_x - b[0], center_y - b[1]),
+    )
+    return (center_x, center_y, radius)
 
 
-def make_circumcircle(a, b, c):
-    # Mathematical algorithm from Wikipedia: Circumscribed circle
-    ox = (min(a[0], b[0], c[0]) + max(a[0], b[0], c[0])) / 2
-    oy = (min(a[1], b[1], c[1]) + max(a[1], b[1], c[1])) / 2
-    ax = a[0] - ox;  ay = a[1] - oy
-    bx = b[0] - ox;  by = b[1] - oy
-    cx = c[0] - ox;  cy = c[1] - oy
-    d = (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 2.0
-    if d == 0.0:
+def _compute_circumcircle(
+    a: Tuple[float, float], b: Tuple[float, float], c: Tuple[float, float]
+) -> Optional[Tuple[float, float, float]]:
+    # Center point
+    mid_x = (min(a[0], b[0], c[0]) + max(a[0], b[0], c[0])) / 2
+    mid_y = (min(a[1], b[1], c[1]) + max(a[1], b[1], c[1])) / 2
+
+    ax, ay = a[0] - mid_x, a[1] - mid_y
+    bx, by = b[0] - mid_x, b[1] - mid_y
+    cx, cy = c[0] - mid_x, c[1] - mid_y
+
+    det = (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 2
+    if det == 0:
         return None
-    x = ox + ((ax*ax + ay*ay) * (by - cy) + (bx*bx + by*by) * (cy - ay) + (cx*cx + cy*cy) * (ay - by)) / d
-    y = oy + ((ax*ax + ay*ay) * (cx - bx) + (bx*bx + by*by) * (ax - cx) + (cx*cx + cy*cy) * (bx - ax)) / d
-    ra = math.hypot(x - a[0], y - a[1])
-    rb = math.hypot(x - b[0], y - b[1])
-    rc = math.hypot(x - c[0], y - c[1])
-    return (x, y, max(ra, rb, rc))
+
+    center_x = (
+        mid_x
+        + (
+            (ax * ax + ay * ay) * (by - cy)
+            + (bx * bx + by * by) * (cy - ay)
+            + (cx * cx + cy * cy) * (ay - by)
+        )
+        / det
+    )
+    center_y = (
+        mid_y
+        + (
+            (ax * ax + ay * ay) * (cx - bx)
+            + (bx * bx + by * by) * (ax - cx)
+            + (cx * cx + cy * cy) * (bx - ax)
+        )
+        / det
+    )
+    radius = max(math.hypot(center_x - p[0], center_y - p[1]) for p in (a, b, c))
+
+    return (center_x, center_y, radius)
 
 
-_MULTIPLICATIVE_EPSILON = 1 + 1e-14
+def _point_in_circle(
+    circle: Optional[Tuple[float, float, float]], point: Tuple[float, float]
+) -> bool:
+    if circle is None:
+        return False
+    return math.hypot(point[0] - circle[0], point[1] - circle[1]) <= circle[2] * (
+        1 + 1e-14
+    )
 
-def is_in_circle(c, p):
-    return c is not None and math.hypot(p[0] - c[0], p[1] - c[1]) <= c[2] * _MULTIPLICATIVE_EPSILON
 
-
-# Returns twice the signed area of the triangle defined by (x0, y0), (x1, y1), (x2, y2).
-def _cross_product(x0, y0, x1, y1, x2, y2):
+def _compute_cross_product(
+    x0: float, y0: float, x1: float, y1: float, x2: float, y2: float
+) -> float:
     return (x1 - x0) * (y2 - y0) - (y1 - y0) * (x2 - x0)
 
 
-def aabc(points):
+def aabc(points: np.ndarray) -> Tuple[float, float, float, float, float]:
+    """
+    Compute axis-aligned bounding cylinder for 3D points.
+
+    Args:
+        points: Nx3 array of points
+
+    Returns:
+        (center_x, center_y, radius, min_z, max_z) tuple
+    """
     points = np.asarray(points)
-    z_min = points[:, 2].min()
-    z_max = points[:, 2].max()
-    x, y, r = make_circle(points[:, :2])
-    return x, y, r, z_min, z_max
+    z_bounds = points[:, 2].min(), points[:, 2].max()
+    center_x, center_y, radius = _compute_smallest_circle(points[:, :2])
+    return center_x, center_y, radius, z_bounds[0], z_bounds[1]


### PR DESCRIPTION
Closes #1208. Adds missing third party license for pytorch3d (we copy rotation conversions code), and rewrites another copied bit of code for bounding cylinder computation.