### PR TITLE
Add missing `device=self.device` in actor.py, base.py, link.py --- allows for `torch.set_default_device("cuda")`

### DIFF
--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -362,7 +362,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
                         raw_pose = new_pose
                     return Pose.create(raw_pose)
         else:
-            return Pose.create([obj.pose for obj in self._objs])
+            return Pose.create([obj.pose for obj in self._objs], device=self.device)
 
     @pose.setter
     def pose(self, arg1: Union[Pose, sapien.Pose, Array]) -> None:

--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -265,7 +265,7 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
             # for link entities, namely 7:10 was angular velocity and 10:13 was linear velocity. SAPIEN 3.0.0 and above fixes this
             return self._body_data[self._body_data_index, 7:10]
         else:
-            return torch.from_numpy(self._bodies[0].linear_velocity[None, :])
+            return torch.from_numpy(self._bodies[0].linear_velocity[None, :]).to(self.device)
 
     @property
     def mass(self) -> torch.Tensor:
@@ -426,7 +426,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
             return self._body_data[self._body_data_index, 7:10]
         else:
             return torch.tensor(
-                np.array([body.linear_velocity for body in self._bodies])
+                np.array([body.linear_velocity for body in self._bodies]), device=self.device
             )
 
     @linear_velocity.setter

--- a/mani_skill/utils/structs/base.py
+++ b/mani_skill/utils/structs/base.py
@@ -209,7 +209,8 @@ class PhysxRigidBodyComponentStruct(PhysxRigidBaseComponentStruct[T], Generic[T]
             return self._body_data[self._body_data_index, 10:13]
         else:
             return torch.tensor(
-                np.array([body.angular_velocity for body in self._bodies])
+                np.array([body.angular_velocity for body in self._bodies]),
+                device=self.device
             )
 
     @property
@@ -356,7 +357,7 @@ class PhysxRigidDynamicComponentStruct(PhysxRigidBodyComponentStruct[T], Generic
         if self.scene.gpu_sim_enabled:
             return self._body_data[self._body_data_index, 10:13]
         else:
-            return torch.from_numpy(self._bodies[0].angular_velocity[None, :])
+            return torch.from_numpy(self._bodies[0].angular_velocity[None, :], device=self.device)
 
     @angular_velocity.setter
     def angular_velocity(self, arg1: Array):

--- a/mani_skill/utils/structs/link.py
+++ b/mani_skill/utils/structs/link.py
@@ -244,7 +244,7 @@ class Link(PhysxRigidBodyComponentStruct[physx.PhysxArticulationLinkComponent]):
                 raw_pose = new_pose
             return Pose.create(raw_pose)
         else:
-            return Pose.create([obj.entity_pose for obj in self._objs])
+            return Pose.create([obj.entity_pose for obj in self._objs], device=self.device)
 
     @pose.setter
     def pose(self, arg1: Union[Pose, sapien.Pose, Array]) -> None:


### PR DESCRIPTION
Fixes a cuda/cpu mismatch bug