### PR TITLE
[Bugfix] Fix vector env shutdown: implement close_extras in ManiSkillVectorEnv (prevents double-close at teardown)

### DIFF
--- a/mani_skill/vector/wrappers/gymnasium.py
+++ b/mani_skill/vector/wrappers/gymnasium.py
@@ -157,8 +157,8 @@ class ManiSkillVectorEnv(VectorEnv):
             # NOTE (stao): Unlike gymnasium, the code here does not add masks for every key in the info object.
         return obs, rew, terminations, truncations, infos
 
-    def close(self):
-        return self._env.close()
+    def close_extras(self, **kwargs):
+        self._env.close()
 
     def call(self, name: str, *args, **kwargs):
         function = getattr(self._env, name)


### PR DESCRIPTION
* Root cause: ManiSkillVectorEnv.close() bypassed VectorEnv.close(), so closed stayed False; VectorEnv.__del__ triggered a second close during interpreter shutdown → sporadic 'NoneType' is not callable'.
* Fix: implement close_extras() to close _env, rely on base VectorEnv.close() to set closed=True and ensure idempotency.
* Scope: minimal change; no public API change.
* Related: Fixes [#999](https://github.com/haosulab/ManiSkill/issues/999).