### PR TITLE
Add missing self.device arguments

### DIFF
--- a/mani_skill/utils/structs/actor.py
+++ b/mani_skill/utils/structs/actor.py
@@ -347,7 +347,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
                 return self.initial_pose
             else:
                 if self.hidden:
-                    return Pose.create(self.before_hide_pose)
+                    return Pose.create(self.before_hide_pose, device=self.device)
                 else:
                     raw_pose = self.px.cuda_rigid_body_data.torch()[
                         self._body_data_index, :7
@@ -360,7 +360,7 @@ class Actor(PhysxRigidDynamicComponentStruct[sapien.Entity]):
                         new_pose[:, 3:] = raw_pose[:, 3:]
                         new_pose[:, :3] = new_xyzs
                         raw_pose = new_pose
-                    return Pose.create(raw_pose)
+                    return Pose.create(raw_pose, device=self.device)
         else:
             return Pose.create([obj.pose for obj in self._objs], device=self.device)
 


### PR DESCRIPTION
Same as https://github.com/haosulab/ManiSkill/pull/1278

Would be good to add a unit test that just does the following to check for this error!

``` python
import torch
import gymnasium as gym
from mani_skill.examples.motionplanning.panda.solutions import solvePickCube

DEVICE = "cuda:0"
torch.set_default_device(DEVICE)

env = gym.make(
      "PickCube-v1",
      num_envs=1,
      obs_mode="rgbd",
      control_mode="pd_joint_pos",
      sim_backend="cpu",
  )
env.reset()
env.step(torch.zeros((1, 8), device='cpu', dtype=torch.float32)) # error
```