### PR TITLE
[BugFix] Replace deprecated pynvml with nvidia-ml-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_dependencies():
         "fast_kinematics==0.2.2;platform_system=='Linux'",
         "IPython",
         "pytorch_kinematics==0.7.6",
-        "pynvml",  # gpu monitoring
+        "nvidia-ml-py",  # gpu monitoring
         "tyro>=0.8.5",  # nice, typed, command line arg parser
         "huggingface_hub",  # we use HF to version control some assets/datasets more easily
         "sapien>=3.0.0;platform_system=='Linux'",
@@ -109,7 +109,7 @@ def main(argv):
                 "build",
                 "twine",
                 "stable_baselines3",
-                "pynvml",
+                "nvidia-ml-py",
                 "pytest-xdist[psutil]",
                 "pytest-forked",
             ],


### PR DESCRIPTION
Replace pynvml with nvidia-ml-py to resolve FutureWarning. The pynvml package is now marked as "Inactive" and redirects to nvidia-ml-py. This change eliminates the deprecation warning while maintaining full API compatibility (nvidia-ml-py provides the pynvml module).

Changes:
- Updated main dependencies: pynvml -> nvidia-ml-py
- Updated dev dependencies: pynvml -> nvidia-ml-py
- No code changes required (API fully compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)