### PR TITLE
[BugFix] Fix AttributeError with gymnasium >= 1.0 in replay_trajectory

### DIFF
--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -276,7 +276,7 @@ def replay_cpu_sim(
                     trajectories[traj_id]["env_states"]
                 )
                 if ori_env is not None:
-                    ori_env.set_state_dict(ori_env_states[0])
+                    ori_env.unwrapped.set_state_dict(ori_env_states[0])
                 env.base_env.set_state_dict(ori_env_states[0])
                 ori_env_states = ori_env_states[1:]
                 if args.save_traj:

--- a/mani_skill/trajectory/utils/actions/conversion.py
+++ b/mani_skill/trajectory/utils/actions/conversion.py
@@ -94,8 +94,8 @@ def from_pd_joint_pos_to_ee(
     if pbar is not None:
         pbar.reset(total=n)
 
-    ori_controller: CombinedController = ori_env.agent.controller
-    controller: CombinedController = env.agent.controller
+    ori_controller: CombinedController = ori_env.unwrapped.agent.controller
+    controller: CombinedController = env.unwrapped.agent.controller
     assert (
         "arm" in ori_controller.controllers
     ), "Could not find the controller for the robot arm. This controller conversion tool requires there to be a key called 'arm' in the controller"
@@ -120,12 +120,12 @@ def from_pd_joint_pos_to_ee(
         if pbar is not None:
             pbar.update()
 
-        ori_action = common.to_tensor(ori_actions[t], device=env.device)
+        ori_action = common.to_tensor(ori_actions[t], device=env.unwrapped.device)
         ori_action_dict = common.to_tensor(
-            ori_controller.to_action_dict(ori_action), device=env.device
+            ori_controller.to_action_dict(ori_action), device=env.unwrapped.device
         )
         output_action_dict = common.to_tensor(
-            ori_action_dict.copy(), device=env.device
+            ori_action_dict.copy(), device=env.unwrapped.device
         )  # do not in-place modify
         ori_env.step(ori_action)
 
@@ -230,8 +230,8 @@ def from_pd_joint_pos(
     if pbar is not None:
         pbar.reset(total=n)
 
-    ori_controller: CombinedController = ori_env.agent.controller
-    controller: CombinedController = env.agent.controller
+    ori_controller: CombinedController = ori_env.unwrapped.agent.controller
+    controller: CombinedController = env.unwrapped.agent.controller
 
     info = {}
 
@@ -273,7 +273,7 @@ def from_pd_joint_pos(
             output_action_dict["arm"] = arm_action
 
             output_action = controller.from_action_dict(
-                common.to_tensor(output_action_dict, device=env.device)
+                common.to_tensor(output_action_dict, device=env.unwrapped.device)
             )
             _, _, _, _, info = env.step(output_action)
             if render:
@@ -298,8 +298,8 @@ def from_pd_joint_delta_pos(
     if pbar is not None:
         pbar.reset(total=n)
 
-    ori_controller: CombinedController = ori_env.agent.controller
-    controller: CombinedController = env.agent.controller
+    ori_controller: CombinedController = ori_env.unwrapped.agent.controller
+    controller: CombinedController = env.unwrapped.agent.controller
     ori_arm_controller: PDJointPosController = ori_controller.controllers["arm"]
 
     assert output_mode == "pd_joint_pos", output_mode
@@ -324,7 +324,7 @@ def from_pd_joint_delta_pos(
 
         output_action_dict["arm"] = arm_action
         output_action = controller.from_action_dict(
-            common.to_tensor(output_action_dict, device=env.device)
+            common.to_tensor(output_action_dict, device=env.unwrapped.device)
         )
         _, _, _, _, info = env.step(output_action)
 

--- a/tests/test_wrapper_attribute_access.py
+++ b/tests/test_wrapper_attribute_access.py
@@ -1,0 +1,234 @@
+"""Test that trajectory replay code correctly accesses BaseEnv attributes
+through gymnasium wrappers using .unwrapped.
+
+This addresses GitHub issue #1366: gymnasium >= 1.0 no longer propagates
+attribute lookups through the wrapper chain, so env.agent, env.device, and
+env.set_state_dict() must be accessed via env.unwrapped.
+"""
+
+import ast
+import os
+import textwrap
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers – lightweight AST inspection
+# ---------------------------------------------------------------------------
+
+
+def _collect_attribute_chains(source: str) -> list[tuple[int, str]]:
+    """Return (line_number, dotted_chain) for every attribute access on
+    variables named ``env`` or ``ori_env`` in *source*.
+
+    For example, ``env.unwrapped.agent`` produces ``"env.unwrapped.agent"``
+    while ``env.step(a)`` produces ``"env.step"``.
+    """
+    tree = ast.parse(source)
+    results: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        # Walk the chain bottom-up to build the dotted string.
+        parts: list[str] = []
+        cur = node
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name) and cur.id in ("env", "ori_env"):
+            parts.append(cur.id)
+            parts.reverse()
+            results.append((node.lineno, ".".join(parts)))
+    return results
+
+
+# Attributes that belong to BaseEnv and are NOT available on gymnasium
+# wrappers (TimeLimitWrapper, RecordEpisode, etc.) in gymnasium >= 1.0.
+_BASE_ENV_ONLY_ATTRS = frozenset(
+    {
+        "agent",
+        "device",
+        "set_state_dict",
+        "get_state_dict",
+        "control_mode",
+        "obs_mode",
+        "control_freq",
+        "backend",
+    }
+)
+
+# Attributes that are fine to call directly on a wrapper because the wrapper
+# itself (or gymnasium.Wrapper) defines them.
+_WRAPPER_SAFE_ATTRS = frozenset(
+    {
+        "step",
+        "reset",
+        "close",
+        "render",
+        "render_human",
+        "action_space",
+        "observation_space",
+        "unwrapped",
+        "base_env",
+        "env",
+        # RecordEpisode specific
+        "save_trajectory",
+        "flush_trajectory",
+        "flush_video",
+        "_trajectory_buffer",
+        "_h5_file",
+    }
+)
+
+
+def _find_unsafe_accesses(source: str) -> list[tuple[int, str]]:
+    """Return a list of (line, chain) where a BaseEnv-only attribute is
+    accessed on ``env`` / ``ori_env`` without going through ``.unwrapped``
+    or ``.base_env`` first.
+    """
+    violations: list[tuple[int, str]] = []
+    for lineno, chain in _collect_attribute_chains(source):
+        parts = chain.split(".")
+        # parts[0] is "env" or "ori_env"
+        if len(parts) < 2:
+            continue
+        first_attr = parts[1]
+        if first_attr in _BASE_ENV_ONLY_ATTRS:
+            # Direct access like env.agent or ori_env.set_state_dict
+            violations.append((lineno, chain))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# The actual tests
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+REPLAY_TRAJECTORY_PATH = os.path.join(
+    _REPO_ROOT, "mani_skill", "trajectory", "replay_trajectory.py"
+)
+CONVERSION_PATH = os.path.join(
+    _REPO_ROOT, "mani_skill", "trajectory", "utils", "actions", "conversion.py"
+)
+
+
+def test_replay_trajectory_no_unsafe_wrapper_attribute_access():
+    """replay_trajectory.py must not access BaseEnv-only attributes
+    directly on wrapped env objects (gymnasium >= 1.0 compatibility)."""
+    with open(REPLAY_TRAJECTORY_PATH) as f:
+        source = f.read()
+    violations = _find_unsafe_accesses(source)
+    assert violations == [], (
+        "Found direct BaseEnv attribute access through wrapper in "
+        f"replay_trajectory.py (needs .unwrapped): {violations}"
+    )
+
+
+def test_conversion_no_unsafe_wrapper_attribute_access():
+    """conversion.py must not access BaseEnv-only attributes directly on
+    wrapped env objects (gymnasium >= 1.0 compatibility)."""
+    with open(CONVERSION_PATH) as f:
+        source = f.read()
+    violations = _find_unsafe_accesses(source)
+    assert violations == [], (
+        "Found direct BaseEnv attribute access through wrapper in "
+        f"conversion.py (needs .unwrapped): {violations}"
+    )
+
+
+def test_unwrapped_is_used_for_agent_access():
+    """conversion.py should use env.unwrapped.agent, not env.agent."""
+    with open(CONVERSION_PATH) as f:
+        source = f.read()
+    chains = _collect_attribute_chains(source)
+    agent_accesses = [(ln, c) for ln, c in chains if "agent" in c.split(".")]
+    for lineno, chain in agent_accesses:
+        parts = chain.split(".")
+        agent_idx = parts.index("agent")
+        assert (
+            agent_idx >= 2 and parts[agent_idx - 1] == "unwrapped"
+        ), f"Line {lineno}: '{chain}' accesses .agent without .unwrapped"
+
+
+def test_unwrapped_is_used_for_device_access():
+    """conversion.py should use env.unwrapped.device, not env.device."""
+    with open(CONVERSION_PATH) as f:
+        source = f.read()
+    chains = _collect_attribute_chains(source)
+    device_accesses = [
+        (ln, c) for ln, c in chains if c.split(".")[-1] == "device" or ".device" in c
+    ]
+    for lineno, chain in device_accesses:
+        parts = chain.split(".")
+        if "device" in parts:
+            device_idx = parts.index("device")
+            assert (
+                device_idx >= 2 and parts[device_idx - 1] == "unwrapped"
+            ), f"Line {lineno}: '{chain}' accesses .device without .unwrapped"
+
+
+def test_unwrapped_is_used_for_set_state_dict():
+    """replay_trajectory.py should use ori_env.unwrapped.set_state_dict,
+    not ori_env.set_state_dict."""
+    with open(REPLAY_TRAJECTORY_PATH) as f:
+        source = f.read()
+    chains = _collect_attribute_chains(source)
+    state_dict_accesses = [(ln, c) for ln, c in chains if "set_state_dict" in c]
+    for lineno, chain in state_dict_accesses:
+        parts = chain.split(".")
+        ssd_idx = parts.index("set_state_dict")
+        # Must be accessed via .unwrapped or .base_env
+        assert ssd_idx >= 2 and parts[ssd_idx - 1] in ("unwrapped", "base_env"), (
+            f"Line {lineno}: '{chain}' accesses .set_state_dict without "
+            ".unwrapped or .base_env"
+        )
+
+
+class TestMockWrapperAttributeAccess:
+    """Simulate the gymnasium >= 1.0 behavior where wrappers do NOT
+    forward attribute lookups to the base environment."""
+
+    def test_timelimit_wrapper_blocks_attribute_access(self):
+        """Verify that our mock correctly blocks direct attribute access,
+        mimicking gymnasium >= 1.0 behavior."""
+
+        class FakeBaseEnv:
+            agent = "fake_agent"
+            device = "cpu"
+
+            def set_state_dict(self, d):
+                pass
+
+        class FakeTimeLimitWrapper:
+            """Mimics gymnasium >= 1.0 wrapper: does NOT propagate attrs."""
+
+            def __init__(self, env):
+                self._env = env
+
+            @property
+            def unwrapped(self):
+                return self._env
+
+            def step(self, action):
+                pass
+
+            def reset(self, **kwargs):
+                pass
+
+        base = FakeBaseEnv()
+        wrapped = FakeTimeLimitWrapper(base)
+
+        # Direct access should fail (like gymnasium >= 1.0)
+        with pytest.raises(AttributeError):
+            _ = wrapped.agent
+        with pytest.raises(AttributeError):
+            _ = wrapped.device
+        with pytest.raises(AttributeError):
+            wrapped.set_state_dict({})
+
+        # .unwrapped access should work
+        assert wrapped.unwrapped.agent == "fake_agent"
+        assert wrapped.unwrapped.device == "cpu"
+        wrapped.unwrapped.set_state_dict({})  # should not raise


### PR DESCRIPTION
## Summary

Fixes #1366

`gymnasium >= 1.0` removed automatic attribute propagation through `Wrapper` chains ([gymnasium changelog](https://gymnasium.farama.org/introduction/migration_guide/)). This causes `AttributeError: 'TimeLimitWrapper' has no attribute 'agent'` (and similar errors for `device`, `set_state_dict`) when running `replay_trajectory.py` with action conversion.

**Root cause**: The trajectory replay and action conversion code accesses `BaseEnv`-only attributes (`.agent`, `.device`, `.set_state_dict()`) directly on wrapped env objects. In gymnasium < 1.0, wrappers automatically forwarded unknown attribute lookups to the base env. In gymnasium >= 1.0, this forwarding was removed.

**Fix**: Use `env.unwrapped.xxx` for `BaseEnv`-only attributes while keeping `env.step()`/`env.reset()` through the wrapper chain (so `RecordEpisode` and other wrappers continue to function correctly).

### Changes

- **`replay_trajectory.py`**: `ori_env.set_state_dict(...)` -> `ori_env.unwrapped.set_state_dict(...)`
- **`conversion.py`**: 11 occurrences of `env.agent`/`env.device` -> `env.unwrapped.agent`/`env.unwrapped.device` across 3 functions (`from_pd_joint_pos_to_ee`, `from_pd_joint_pos`, `from_pd_joint_delta_pos`)
- **New test file**: `tests/test_wrapper_attribute_access.py` — AST-based regression tests that statically verify no unsafe direct attribute access patterns exist

## Test Results

<details>
<summary>Before (without fix) — 5 FAILED, 1 passed</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /home/devuser/workspace/public-oss/embodied-robotics/myenv-maniskill-1366/bin/python
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/public-oss/embodied-robotics/worktree-maniskill-1366
configfile: pyproject.toml
plugins: typeguard-4.5.1, xdist-3.8.0, anyio-4.13.0, forked-1.6.0
collecting ... collected 6 items

tests/test_wrapper_attribute_access.py::test_replay_trajectory_no_unsafe_wrapper_attribute_access FAILED [ 16%]
tests/test_wrapper_attribute_access.py::test_conversion_no_unsafe_wrapper_attribute_access FAILED [ 33%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_agent_access FAILED [ 50%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_device_access FAILED [ 66%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_set_state_dict FAILED [ 83%]
tests/test_wrapper_attribute_access.py::TestMockWrapperAttributeAccess::test_timelimit_wrapper_blocks_attribute_access PASSED [100%]

=================================== FAILURES ===================================
__________ test_replay_trajectory_no_unsafe_wrapper_attribute_access ___________

    def test_replay_trajectory_no_unsafe_wrapper_attribute_access():
        """replay_trajectory.py must not access BaseEnv-only attributes
        directly on wrapped env objects (gymnasium >= 1.0 compatibility)."""
        with open(REPLAY_TRAJECTORY_PATH) as f:
            source = f.read()
        violations = _find_unsafe_accesses(source)
>       assert violations == [], (
            "Found direct BaseEnv attribute access through wrapper in "
            f"replay_trajectory.py (needs .unwrapped): {violations}"
        )
E       AssertionError: Found direct BaseEnv attribute access through wrapper in replay_trajectory.py (needs .unwrapped): [(279, 'ori_env.set_state_dict')]
E       assert [(279, 'ori_e..._state_dict')] == []
E
E         Left contains one more item: (279, 'ori_env.set_state_dict')
E
E         Full diff:
E         - []
E         + [
E         +     (...
E
E         ...Full output truncated (4 lines hidden), use '-vv' to show

tests/test_wrapper_attribute_access.py:119: AssertionError
______________ test_conversion_no_unsafe_wrapper_attribute_access ______________

    def test_conversion_no_unsafe_wrapper_attribute_access():
        """conversion.py must not access BaseEnv-only attributes directly on
        wrapped env objects (gymnasium >= 1.0 compatibility)."""
        with open(CONVERSION_PATH) as f:
            source = f.read()
        violations = _find_unsafe_accesses(source)
>       assert violations == [], (
            "Found direct BaseEnv attribute access through wrapper in "
            f"conversion.py (needs .unwrapped): {violations}"
        )
E       AssertionError: Found direct BaseEnv attribute access through wrapper in conversion.py (needs .unwrapped): [(97, 'ori_env.agent.controller'), (98, 'env.agent.controller'), (233, 'ori_env.agent.controller'), (234, 'env.agent.controller'), (301, 'ori_env.agent.controller'), (302, 'env.agent.controller'), (97, 'ori_env.agent'), (98, 'env.agent'), (233, 'ori_env.agent'), (234, 'env.agent'), (301, 'ori_env.agent'), (302, 'env.agent'), (123, 'env.device'), (125, 'env.device'), (128, 'env.device'), (327, 'env.device'), (276, 'env.device')]
E       assert [(97, 'ori_en...roller'), ...] == []
E
E         Left contains 17 more items, first extra item: (97, 'ori_env.agent.controller')
E
E         Full diff:
E         - []
E         + [
E         +     (...
E
E         ...Full output truncated (68 lines hidden), use '-vv' to show

tests/test_wrapper_attribute_access.py:131: AssertionError
___________________ test_unwrapped_is_used_for_agent_access ____________________

    def test_unwrapped_is_used_for_agent_access():
        """conversion.py should use env.unwrapped.agent, not env.agent."""
        with open(CONVERSION_PATH) as f:
            source = f.read()
        chains = _collect_attribute_chains(source)
        agent_accesses = [
            (ln, c) for ln, c in chains
            if "agent" in c.split(".")
        ]
        for lineno, chain in agent_accesses:
            parts = chain.split(".")
            agent_idx = parts.index("agent")
>           assert agent_idx >= 2 and parts[agent_idx - 1] == "unwrapped", (
                f"Line {lineno}: '{chain}' accesses .agent without .unwrapped"
            )
E           AssertionError: Line 97: 'ori_env.agent.controller' accesses .agent without .unwrapped
E           assert (1 >= 2)

tests/test_wrapper_attribute_access.py:149: AssertionError
___________________ test_unwrapped_is_used_for_device_access ___________________

    def test_unwrapped_is_used_for_device_access():
        """conversion.py should use env.unwrapped.device, not env.device."""
        with open(CONVERSION_PATH) as f:
            source = f.read()
        chains = _collect_attribute_chains(source)
        device_accesses = [
            (ln, c) for ln, c in chains
            if c.split(".")[-1] == "device" or ".device" in c
        ]
        for lineno, chain in device_accesses:
            parts = chain.split(".")
            if "device" in parts:
                device_idx = parts.index("device")
>               assert device_idx >= 2 and parts[device_idx - 1] == "unwrapped", (
                    f"Line {lineno}: '{chain}' accesses .device without .unwrapped"
                )
E               AssertionError: Line 123: 'env.device' accesses .device without .unwrapped
E               assert (1 >= 2)

tests/test_wrapper_attribute_access.py:167: AssertionError
__________________ test_unwrapped_is_used_for_set_state_dict ___________________

    def test_unwrapped_is_used_for_set_state_dict():
        """replay_trajectory.py should use ori_env.unwrapped.set_state_dict,
        not ori_env.set_state_dict."""
        with open(REPLAY_TRAJECTORY_PATH) as f:
            source = f.read()
        chains = _collect_attribute_chains(source)
        state_dict_accesses = [
            (ln, c) for ln, c in chains
            if "set_state_dict" in c
        ]
        for lineno, chain in state_dict_accesses:
            parts = chain.split(".")
            ssd_idx = parts.index("set_state_dict")
            # Must be accessed via .unwrapped or .base_env
>           assert ssd_idx >= 2 and parts[ssd_idx - 1] in ("unwrapped", "base_env"), (
                f"Line {lineno}: '{chain}' accesses .set_state_dict without "
                ".unwrapped or .base_env"
            )
E           AssertionError: Line 279: 'ori_env.set_state_dict' accesses .set_state_dict without .unwrapped or .base_env
E           assert (1 >= 2)

tests/test_wrapper_attribute_access.py:186: AssertionError
=========================== short test summary info ============================
FAILED tests/test_wrapper_attribute_access.py::test_replay_trajectory_no_unsafe_wrapper_attribute_access
FAILED tests/test_wrapper_attribute_access.py::test_conversion_no_unsafe_wrapper_attribute_access
FAILED tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_agent_access
FAILED tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_device_access
FAILED tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_set_state_dict
========================= 5 failed, 1 passed in 0.07s ==========================
```

</details>

<details>
<summary>After (with fix) — 6 passed</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /home/devuser/workspace/public-oss/embodied-robotics/myenv-maniskill-1366/bin/python
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/public-oss/embodied-robotics/worktree-maniskill-1366
configfile: pyproject.toml
plugins: typeguard-4.5.1, xdist-3.8.0, anyio-4.13.0, forked-1.6.0
collecting ... collected 6 items

tests/test_wrapper_attribute_access.py::test_replay_trajectory_no_unsafe_wrapper_attribute_access PASSED [ 16%]
tests/test_wrapper_attribute_access.py::test_conversion_no_unsafe_wrapper_attribute_access PASSED [ 33%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_agent_access PASSED [ 50%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_device_access PASSED [ 66%]
tests/test_wrapper_attribute_access.py::test_unwrapped_is_used_for_set_state_dict PASSED [ 83%]
tests/test_wrapper_attribute_access.py::TestMockWrapperAttributeAccess::test_timelimit_wrapper_blocks_attribute_access PASSED [100%]

============================== 6 passed in 0.03s ===============================
```

</details>

## Test Plan

- [x] AST-based static analysis tests verify no unsafe `env.agent`/`env.device`/`env.set_state_dict` patterns in modified files
- [x] Mock wrapper test simulates gymnasium >= 1.0 behavior (wrapper blocks attribute forwarding, `.unwrapped` works)
- [x] `env.step()`/`env.reset()` calls are preserved through the wrapper chain (not changed to `env.unwrapped.step()`) to ensure `RecordEpisode` and other wrappers continue to intercept these calls
- [ ] End-to-end: `python -m mani_skill.trajectory.replay_trajectory --traj-path trajectory.h5 -c pd_ee_delta_pos -o rgb --save-traj` (requires GPU/Vulkan — not available in this CI environment)