### PR TITLE
fix: ManiSkillSB3VectorEnv accesses wrapped env attributes via base_env

### DIFF
--- a/mani_skill/vector/wrappers/sb3.py
+++ b/mani_skill/vector/wrappers/sb3.py
@@ -31,10 +31,10 @@ class ManiSkillSB3VectorEnv(SB3VecEnv):
     """A wrapper for to make ManiSkill parallel simulation compatible with SB3 VecEnv and auto adds the monitor wrapper"""
 
     def __init__(self, env: BaseEnv):
-        super().__init__(
-            env.num_envs, env.single_observation_space, env.single_action_space
-        )
         self._env = env
+        super().__init__(
+            self.base_env.num_envs, self.base_env.single_observation_space, self.base_env.single_action_space
+        )
         self._last_seed = None
         self.t_start = time.time()
         self.episode_returns: torch.Tensor = torch.zeros(


### PR DESCRIPTION
## Problem

When `gym.make()` wraps the ManiSkill vector env in a `TimeLimitWrapper`, the resulting env object no longer has `num_envs`, `single_observation_space`, or `single_action_space` attributes directly. These exist only on the underlying `BaseEnv`.

Calling `ManiSkillSB3VectorEnv(ms3_vec_env)` where `ms3_vec_env` is a `TimeLimitWrapper` causes:

```
AttributeError: 'TimeLimitWrapper' object has no attribute 'num_envs'
```

## Fix

Set `self._env = env` before calling `super().__init__()`, then use `self.base_env` (which returns `self._env.unwrapped`, i.e., the `BaseEnv`) to access `num_envs`, `single_observation_space`, and `single_action_space`.

This is consistent with how `self.base_env` is already used elsewhere in the class (e.g., `self.base_env.device` on lines 41-47).

Fixes #1404