### PR TITLE
fix: normalize episode_seed type to prevent TypeError in replay_trajectory

### DIFF
--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -94,6 +94,14 @@ class ReplayResult:
 
 def sanity_check_and_format_seed(episode):
     """sanity checks the trajectory seed aligns with the episode seed. reformats the reset kwargs seed if missing or formatted wrong"""
+    # normalize episode_seed to a scalar int (may be stored as numpy array or list)
+    episode_seed = episode["episode_seed"]
+    if isinstance(episode_seed, np.ndarray):
+        episode_seed = episode_seed.item() if episode_seed.ndim == 0 else episode_seed[0]
+    elif isinstance(episode_seed, (list, tuple)):
+        episode_seed = episode_seed[0]
+    episode["episode_seed"] = int(episode_seed)
+
     if "seed" in episode["reset_kwargs"]:
         if isinstance(episode["reset_kwargs"]["seed"], list):
 

--- a/mani_skill/trajectory/replay_trajectory.py
+++ b/mani_skill/trajectory/replay_trajectory.py
@@ -97,8 +97,19 @@ def sanity_check_and_format_seed(episode):
     # normalize episode_seed to a scalar int (may be stored as numpy array or list)
     episode_seed = episode["episode_seed"]
     if isinstance(episode_seed, np.ndarray):
-        episode_seed = episode_seed.item() if episode_seed.ndim == 0 else episode_seed[0]
+        if episode_seed.ndim == 0:
+            episode_seed = episode_seed.item()
+        else:
+            assert episode_seed.size == 1, (
+                f"found multiple seeds for one trajectory (id={episode['episode_id']}) "
+                "in episode_seed which means it is ambiguous which seed to use"
+            )
+            episode_seed = episode_seed.reshape(-1)[0]
     elif isinstance(episode_seed, (list, tuple)):
+        assert len(episode_seed) == 1, (
+            f"found multiple seeds for one trajectory (id={episode['episode_id']}) "
+            "in episode_seed which means it is ambiguous which seed to use"
+        )
         episode_seed = episode_seed[0]
     episode["episode_seed"] = int(episode_seed)
 


### PR DESCRIPTION
## Summary

- Fixed `TypeError: 'int' object is not subscriptable` when using `--use-env-states` with `--record-rewards` and observation recording flags in `replay_trajectory`
- The `episode_seed` field can be stored as a numpy array, list, or scalar int depending on how the trajectory was collected
- Added normalization logic to convert `episode_seed` to a scalar int before comparison or assignment
- Handles numpy arrays (0-d and 1-d), lists, tuples, and plain ints

Fixes #1413

## Test Plan

- [ ] `python -m mani_skill.trajectory.replay_trajectory --traj-path <path> --record-rewards --use-env-states --save-traj` no longer raises TypeError
- [ ] Existing replay functionality continues to work without `--use-env-states`