### PR TITLE
fix: bound x-offset at both ends in PegInsertionSide success condition

### DIFF
--- a/mani_skill/envs/tasks/tabletop/peg_insertion_side.py
+++ b/mani_skill/envs/tasks/tabletop/peg_insertion_side.py
@@ -270,7 +270,7 @@ class PegInsertionSideEnv(BaseEnv):
         # Only head position is used in fact
         peg_head_pos_at_hole = (self.box_hole_pose.inv() * self.peg_head_pose).p
         # x-axis is hole direction
-        x_flag = -0.015 <= peg_head_pos_at_hole[:, 0]
+        x_flag = (-0.015 <= peg_head_pos_at_hole[:, 0]) & (peg_head_pos_at_hole[:, 0] <= 0.015)
         y_flag = (-self.box_hole_radii <= peg_head_pos_at_hole[:, 1]) & (
             peg_head_pos_at_hole[:, 1] <= self.box_hole_radii
         )


### PR DESCRIPTION
## Summary

- Fixed the `PegInsertionSide` task success condition to bound the x-offset at both the top and bottom
- Previously only checked `-0.015 <= x`, allowing the peg to overshoot past the hole and still be counted as success
- Now checks `-0.015 <= x <= 0.015`, requiring the peg head to be within ±1.5cm of the ideal insertion position along the x-axis

Fixes #1391

## Test Plan

- [ ] PegInsertionSide task no longer reports success when peg overshoots past the hole
- [ ] Normal successful insertions are still correctly detected
- [ ] No regression on other peg insertion tasks