### PR TITLE
Fix scalar-seeded main RNG expansion shrinking the episode seed batch

### DIFF
--- a/mani_skill/envs/sapien_env.py
+++ b/mani_skill/envs/sapien_env.py
@@ -1001,7 +1001,7 @@ class BaseEnv(gym.Env):
         self._main_seed = seed_list
         self._main_rng = np.random.RandomState(self._main_seed[0])
         if len(self._main_seed) == 1 and self.num_envs > 1:
-            self._main_seed = self._main_seed + np.random.RandomState(self._main_seed[0]).randint(2**31, size=(self.num_envs - 1,)).tolist()
+            self._main_seed = np.concatenate((self._main_seed, np.random.RandomState(self._main_seed[0]).randint(2**31, size=(self.num_envs - 1,))))
         self._batched_main_rng = BatchedRNG.from_seeds(self._main_seed, backend=self._batched_rng_backend)
 
     def _set_episode_rng(self, seed: Union[None, list[int], np.ndarray[Any], int], env_idx: torch.Tensor):

--- a/tests/test_gpu_envs.py
+++ b/tests/test_gpu_envs.py
@@ -189,6 +189,24 @@ def test_env_reconfiguration(env_id):
 #     del env
 
 
+# Unlike the reproducibility tests above, this only checks the batch size of the episode seeds, which is
+# deterministic even though GPU sim is not.
+@pytest.mark.gpu_sim
+def test_seeded_then_unseeded_reset_keeps_episode_seed_batch_size():
+    # Regression for #1456: a scalar-seeded reset expanded the main seed with `+` (numpy broadcast, which
+    # yields num_envs-1 entries) instead of np.concatenate, so a following unseeded reset under
+    # reconfiguration shrank _episode_seed to num_envs-1.
+    num_envs = 4
+    env = gym.make(ENV_IDS[0], num_envs=num_envs, reconfiguration_freq=1)
+    base: BaseEnv = env.unwrapped
+    env.reset(seed=1)
+    assert len(base._episode_seed) == num_envs
+    env.reset()
+    assert len(base._episode_seed) == num_envs
+    env.close()
+    del env
+
+
 # def test_env_raise_value_error_for_nan_actions():
 #     env = gym.make(ENV_IDS[0])
 #     obs, _ = env.reset(seed=2000)


### PR DESCRIPTION
## What

`BaseEnv._set_main_rng` expanded a length-1 main seed with `array + list`:

```python
self._main_seed = self._main_seed + np.random.RandomState(...).randint(2**31, size=(self.num_envs - 1,)).tolist()
```

`np.array([seed]) + [a, b, c]` is a numpy **broadcast**, not a concatenation, so it yields `num_envs - 1` entries (`[seed+a, seed+b, seed+c]`) instead of `num_envs`. `_batched_main_rng` is then built from that short list, and a later unseeded reset under reconfiguration seeds the episodes from it (`_set_episode_rng(self._batched_main_rng.randint(...))`), leaving `_episode_seed` at `num_envs - 1`.

Repro from #1456 (`num_envs=4`):
```python
env.reset(seed=1); len(base._episode_seed)  # 4
env.reset();       len(base._episode_seed)  # 3  <- should be 4
```

## Fix

Use `np.concatenate`, matching the sibling `_set_episode_rng` which already does this:
```python
self._main_seed = np.concatenate((self._main_seed, np.random.RandomState(self._main_seed[0]).randint(2**31, size=(self.num_envs - 1,))))
```
This also corrects the seed *values* — the first env keeps the user seed instead of `seed + derived`.

## Test

Added `test_seeded_then_unseeded_reset_keeps_episode_seed_batch_size` to `tests/test_gpu_envs.py` (the bug needs `num_envs > 1`, i.e. the CUDA backend). Unlike the commented-out reproducibility tests there, it only asserts the `_episode_seed` batch size — deterministic even though GPU sim isn't — so it's safe to run.

I verified the broadcast-vs-concatenate behaviour locally in isolation; I don't have a CUDA box to run the env-level test, so it targets your GPU CI.

Fixes #1456