### PR TITLE
[BugFix] Fix flatten_state_dict when use_torch=False

### DIFF
--- a/mani_skill/utils/common.py
+++ b/mani_skill/utils/common.py
@@ -230,11 +230,13 @@ def flatten_state_dict(
 
     for key, value in state_dict.items():
         if isinstance(value, dict):
-            state = flatten_state_dict(value, use_torch=use_torch)
-            if state.nelement() == 0:
+            state = flatten_state_dict(
+                value,
+                use_torch=use_torch,
+                device=device,
+            )
+            if (state.nelement() if use_torch else state.size) == 0:
                 state = None
-            elif use_torch:
-                state = to_tensor(state, device=device)
         elif isinstance(value, (tuple, list)):
             state = None if len(value) == 0 else value
             if use_torch:


### PR DESCRIPTION
## Summary

This fixes an issue in `flatten_state_dict` when `use_torch=False`.

Previously, recursive calls always checked `state.nelement()`, which raises an `AttributeError` for NumPy arrays because `numpy.ndarray` does not implement `nelement()`.

This PR:
- uses `state.size` when `use_torch=False`;
- passes `device` through recursive calls to preserve the requested device.

## Example

```python
# Before:
flatten_state_dict(state_dict, use_torch=False)
# AttributeError: 'numpy.ndarray' object has no attribute 'nelement'

# After:
flatten_state_dict(state_dict, use_torch=False)
# Works as expected.