### PR TITLE
[Feature] Demonstrate actor builder API in PushCube

### DIFF
--- a/mani_skill/envs/tasks/tabletop/push_cube.py
+++ b/mani_skill/envs/tasks/tabletop/push_cube.py
@@ -109,17 +109,20 @@ class PushCubeEnv(BaseEnv):
         )
         self.table_scene.build()
 
-        # we then add the cube that we want to push and give it a color and size using a convenience build_cube function
-        # we specify the body_type to be "dynamic" as it should be able to move when touched by other objects / the robot
-        # finally we specify an initial pose for the cube so that it doesn't collide with other objects initially
-        self.obj = actors.build_cube(
-            self.scene,
-            half_size=self.cube_half_size,
-            color=np.array([12, 42, 160, 255]) / 255,
-            name="cube",
-            body_type="dynamic",
-            initial_pose=sapien.Pose(p=[0, 0, self.cube_half_size]),
+        # we then add the cube that we want to push using the actor builder API
+        # convenience functions like actors.build_cube can also build common primitive shapes
+        builder = self.scene.create_actor_builder()
+        builder.add_box_collision(half_size=[self.cube_half_size] * 3)
+        builder.add_box_visual(
+            half_size=[self.cube_half_size] * 3,
+            material=sapien.render.RenderMaterial(
+                base_color=np.array([12, 42, 160, 255]) / 255
+            ),
         )
+        # specify an initial pose so the cube does not collide with other objects while the scene is loading
+        builder.set_initial_pose(sapien.Pose(p=[0, 0, self.cube_half_size]))
+        # build a dynamic actor so the cube can move when touched by the robot
+        self.obj = builder.build(name="cube")
 
         # we also add in red/white target to visualize where we want the cube to be pushed to
         # we specify add_collisions=False as we only use this as a visual for videos and do not want it to affect the actual physics


### PR DESCRIPTION
## Summary

- replace the `actors.build_cube` call in `PushCubeEnv._load_scene` with the lower-level actor builder API
- define the cube's box collision, visual material, initial pose, and dynamic body explicitly
- keep a nearby comment pointing task authors to `actors.build_cube` for common primitive shapes

`PushCube-v1` is used as a minimal task example. This makes the underlying actor construction steps visible while preserving the existing cube behavior.

Closes #1453

## Consistency with the tutorial

The custom tasks tutorial already teaches this exact sequence in `docs/source/user_guide/tutorials/custom_tasks/intro.md` (lines 92-106): `self.scene.create_actor_builder()`, then `add_box_collision`, `add_box_visual` with a `sapien.render.RenderMaterial`, then `builder.build(name="cube")`. That page also tells readers to follow it "alongside the annotated code for the PushCube task".

Until now the task file used the `actors.build_cube` wrapper instead, so the two did not line up for a reader following both. This change makes the annotated task match the tutorial it is paired with, down to the `builder` variable name.

## Behavior

No behavior change. Expanding `actors.build_cube` and `_build_by_type` with the original call's arguments gives the same six steps in the same order: `create_actor_builder`, `add_box_collision(half_size=[h] * 3)`, `add_box_visual(half_size=[h] * 3, material=RenderMaterial(base_color=color))`, no `set_scene_idxs` because `scene_idxs` was `None`, `set_initial_pose`, and `build(name=...)` for `body_type="dynamic"`.

## Testing

- `pytest -q 'tests/test_envs.py::test_all_envs[PushCube-v1]'`
- CPU PhysX reset and five-step smoke test
- verified the built actor is dynamic with a box collision half-size of `[0.02, 0.02, 0.02]`
- `pre-commit run --files mani_skill/envs/tasks/tabletop/push_cube.py`
